### PR TITLE
Add command line runner for cmd line tools , hook render up to it

### DIFF
--- a/apps/VC/VCMain.ui
+++ b/apps/VC/VCMain.ui
@@ -135,7 +135,7 @@
     <bool>false</bool>
    </property>
    <property name="features">
-    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
+    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetResizable</set>
    </property>
    <property name="allowedAreas">
     <set>Qt::LeftDockWidgetArea|Qt::RightDockWidgetArea</set>
@@ -305,7 +305,7 @@
     <bool>false</bool>
    </property>
    <property name="features">
-    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
+    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetResizable</set>
    </property>
    <property name="allowedAreas">
     <set>Qt::LeftDockWidgetArea|Qt::RightDockWidgetArea</set>

--- a/apps/VC3D/CMakeLists.txt
+++ b/apps/VC3D/CMakeLists.txt
@@ -25,6 +25,10 @@ set(srcs
     CSegmentationEditorWindow.hpp
     SegmentRenderThread.cpp
     SegmentRenderThread.hpp
+    ProgressUtil.cpp
+    ProgressUtil.hpp
+    CommandLineToolRunner.cpp
+    CommandLineToolRunner.hpp
 )
 
 set(MACOSX_BUNDLE_ICON logo.icns)

--- a/apps/VC3D/CWindow.hpp
+++ b/apps/VC3D/CWindow.hpp
@@ -6,6 +6,7 @@
 #include <opencv2/core.hpp>
 #include "ui_VCMain.h"
 
+#include "CommandLineToolRunner.hpp"
 #include "vc/core/util/SurfaceDef.hpp"
 
 #define MAX_RECENT_VOLPKG 10
@@ -32,7 +33,6 @@ class OpsList;
 class OpsSettings;
 class SurfaceTreeWidget;
 class SurfaceTreeWidgetItem;
-class SegmentRenderThread;
 
 namespace ChaoVis
 {
@@ -67,9 +67,6 @@ public slots:
     void onResetPoints(void);
     void onSurfaceContextMenuRequested(const QPoint& pos);
     void onRenderSegment(const SurfaceID& segmentId);
-    void onRenderingStarted(const QString& message);
-    void onRenderingFinished(const QString& message);
-    void onRenderingFailed(const QString& errorMessage);
 
 public:
     CWindow();
@@ -184,8 +181,8 @@ private:
     std::unordered_map<std::string, OpChain*> _opchains;
     std::unordered_map<std::string, SurfaceMeta*> _vol_qsurfs;
     
-    // Segment rendering
-    SegmentRenderThread* _renderThread;
+    // runner for command line tools 
+    CommandLineToolRunner* _cmdRunner;
 };  // class CWindow
 
 }  // namespace ChaoVis

--- a/apps/VC3D/CommandLineToolRunner.cpp
+++ b/apps/VC3D/CommandLineToolRunner.cpp
@@ -1,0 +1,278 @@
+#include "CommandLineToolRunner.hpp"
+#include <QDir>
+#include <QFileInfo>
+#include <QStatusBar>
+
+namespace ChaoVis {
+
+CommandLineToolRunner::CommandLineToolRunner(QStatusBar* statusBar, QObject* parent)
+    : QObject(parent)
+    , _progressUtil(new ProgressUtil(statusBar, this))
+    , _process(nullptr)
+    , _scale(1.0f)
+    , _resolution(0)
+    , _layers(21)
+    , _seed_x(0)
+    , _seed_y(0)
+    , _seed_z(0)
+{
+}
+
+CommandLineToolRunner::~CommandLineToolRunner()
+{
+    if (_process) {
+        if (_process->state() != QProcess::NotRunning) {
+            _process->terminate();
+            _process->waitForFinished(3000);
+        }
+        delete _process;
+    }
+}
+
+void CommandLineToolRunner::setVolumePath(const QString& path)
+{
+    _volumePath = path;
+}
+
+void CommandLineToolRunner::setSegmentPath(const QString& path)
+{
+    _segmentPath = path;
+}
+
+void CommandLineToolRunner::setOutputPattern(const QString& pattern)
+{
+    _outputPattern = pattern;
+}
+
+void CommandLineToolRunner::setRenderParams(float scale, int resolution, int layers)
+{
+    _scale = scale;
+    _resolution = resolution;
+    _layers = layers;
+}
+
+void CommandLineToolRunner::setGrowParams(QString volumePath, QString tgtDir, QString jsonParams, int seed_x, int seed_y, int seed_z)
+{
+    _volumePath = volumePath;
+    _tgtDir = tgtDir;
+    _jsonParams = jsonParams;
+    _seed_x = seed_x;
+    _seed_y = seed_y;
+    _seed_z = seed_z;
+}
+
+void CommandLineToolRunner::setTraceParams(QString volumePath, QString srcDir, QString tgtDir, QString jsonParams, QString srcSegment)
+{
+    _volumePath = volumePath;
+    _srcDir = srcDir;
+    _tgtDir = tgtDir;
+    _jsonParams = jsonParams;
+    _srcSegment = srcSegment;
+}
+
+void CommandLineToolRunner::setAddOverlapParams(QString tgtDir, QString tifxyzPath)
+{
+    _tgtDir = tgtDir;
+    _tifxyzPath = tifxyzPath;
+}
+
+void CommandLineToolRunner::setToObjParams(QString tifxyzPath, QString objPath)
+{
+    _tifxyzPath = tifxyzPath;
+    _objPath = objPath;
+}
+
+bool CommandLineToolRunner::execute(Tool tool)
+{
+    if (_process && _process->state() != QProcess::NotRunning) {
+        QMessageBox::warning(nullptr, tr("Warning"), tr("A tool is already running."));
+        return false;
+    }
+    
+    if (_volumePath.isEmpty()) {
+        QMessageBox::warning(nullptr, tr("Error"), tr("Volume path not specified."));
+        return false;
+    }
+    
+    if (_segmentPath.isEmpty() && (tool == Tool::RenderTifXYZ || tool == Tool::GrowSegFromSegment)) {
+        QMessageBox::warning(nullptr, tr("Error"), tr("Segment path not specified."));
+        return false;
+    }
+    
+    if (_outputPattern.isEmpty()) {
+        QMessageBox::warning(nullptr, tr("Error"), tr("Output pattern not specified."));
+        return false;
+    }
+    
+    QFileInfo outputInfo(_outputPattern);
+    QDir outputDir = outputInfo.dir();
+    if (!outputDir.exists()) {
+        if (!outputDir.mkpath(".")) {
+            QMessageBox::warning(nullptr, tr("Error"), tr("Failed to create output directory: %1").arg(outputDir.path()));
+            return false;
+        }
+    }
+    
+    _currentTool = tool;
+    
+    if (!_process) {
+        _process = new QProcess(this);
+        _process->setProcessChannelMode(QProcess::MergedChannels);
+        
+        connect(_process, &QProcess::started, this, &CommandLineToolRunner::onProcessStarted);
+        connect(_process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), 
+                this, &CommandLineToolRunner::onProcessFinished);
+        connect(_process, &QProcess::errorOccurred, this, &CommandLineToolRunner::onProcessError);
+    }
+    
+    QStringList args = buildArguments(tool);
+    QString toolCommand = toolName(tool);
+    
+    QString startMessage = tr("Starting %1 for: %2").arg(toolCommand).arg(QFileInfo(_segmentPath).fileName());
+    emit toolStarted(_currentTool, startMessage);
+    
+    _process->start(toolCommand, args);
+    
+    return true;
+}
+
+void CommandLineToolRunner::cancel()
+{
+    if (_process && _process->state() != QProcess::NotRunning) {
+        _process->terminate();
+    }
+}
+
+bool CommandLineToolRunner::isRunning() const
+{
+    return (_process && _process->state() != QProcess::NotRunning);
+}
+
+void CommandLineToolRunner::onProcessStarted()
+{
+    QString message = tr("Running %1...").arg(toolName(_currentTool));
+    _progressUtil->startAnimation(message);
+}
+
+void CommandLineToolRunner::onProcessFinished(int exitCode, QProcess::ExitStatus exitStatus)
+{
+    if (exitCode == 0 && exitStatus == QProcess::NormalExit) {
+        QString message = tr("%1 completed successfully").arg(toolName(_currentTool));
+        QString outputPath = getOutputPath();
+        
+        // the runner can copy the output of a process to the clipboard, currently this only makes sense for rendering
+        // so the user can quickly open the output dir
+        bool copyToClipboard = (_currentTool == Tool::RenderTifXYZ);
+        
+        if (copyToClipboard) {
+            QApplication::clipboard()->setText(outputPath);
+            _progressUtil->stopAnimation(message + tr(" - Path copied to clipboard"));
+        } else {
+            _progressUtil->stopAnimation(message);
+        }
+        
+        emit toolFinished(_currentTool, true, message, outputPath, copyToClipboard);
+    } else {
+        QString errorMessage = tr("%1 failed with exit code: %2")
+                                .arg(toolName(_currentTool))
+                                .arg(exitCode);
+        
+        _progressUtil->stopAnimation(tr("Process failed"));
+        
+        emit toolFinished(_currentTool, false, errorMessage, QString(), false);
+    }
+}
+
+void CommandLineToolRunner::onProcessError(QProcess::ProcessError error)
+{
+    QString errorMessage = tr("Error running %1: ").arg(toolName(_currentTool));
+    
+    switch (error) {
+        case QProcess::FailedToStart: errorMessage += tr("failed to start"); break;
+        case QProcess::Crashed: errorMessage += tr("crashed"); break;
+        case QProcess::Timedout: errorMessage += tr("timed out"); break;
+        case QProcess::WriteError: errorMessage += tr("write error"); break;
+        case QProcess::ReadError: errorMessage += tr("read error"); break;
+        default: errorMessage += tr("unknown error"); break;
+    }
+    
+    _progressUtil->stopAnimation(tr("Process failed"));
+    
+    emit toolFinished(_currentTool, false, errorMessage, QString(), false);
+}
+
+QStringList CommandLineToolRunner::buildArguments(Tool tool)
+{
+    QStringList args;
+    
+    switch (tool) {
+        case Tool::RenderTifXYZ:
+            args << _volumePath
+                 << _outputPattern
+                 << _segmentPath
+                 << QString::number(_scale)
+                 << QString::number(_resolution)
+                 << QString::number(_layers);
+            break;
+            
+        case Tool::GrowSegFromSegment:
+            args << _volumePath
+                 << _srcDir
+                 << _tgtDir
+                 << _jsonParams
+                 << _srcSegment;
+            break;
+            
+        case Tool::GrowSegFromSeeds:
+            args << _volumePath
+                 << _tgtDir
+                 << _jsonParams
+                 << QString::number(_seed_x)
+                 << QString::number(_seed_y)
+                 << QString::number(_seed_z);
+            break;
+        
+        case Tool::SegAddOverlap:
+            args << _tgtDir
+                 << _tifxyzPath;
+            break;
+        
+        case Tool::tifxyz2obj:
+            args << _tifxyzPath
+                 << _objPath;
+            break;
+    }
+    
+    return args;
+}
+
+QString CommandLineToolRunner::toolName(Tool tool) const
+{
+    switch (tool) {
+        case Tool::RenderTifXYZ:
+            return "vc_render_tifxyz";
+            
+        case Tool::GrowSegFromSegment:
+            return "vc_grow_seg_from_segment";
+            
+        case Tool::GrowSegFromSeeds:
+            return "vc_grow_seg_from_seeds";
+        
+        case Tool::SegAddOverlap:
+            return "vc_seg_add_overlap";
+        
+        case Tool::tifxyz2obj:
+            return "vc_tifxyz2obj";
+            
+        default:
+            return "unknown_tool";
+    }
+}
+
+QString CommandLineToolRunner::getOutputPath() const
+{
+    QFileInfo outputInfo(_outputPattern);
+    return outputInfo.dir().path();
+}
+
+} // namespace ChaoVis

--- a/apps/VC3D/CommandLineToolRunner.hpp
+++ b/apps/VC3D/CommandLineToolRunner.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QProcess>
+#include <QMessageBox>
+#include <QApplication>
+#include <QClipboard>
+#include <memory>
+
+#include "ProgressUtil.hpp"
+#include "vc/core/util/SurfaceDef.hpp"
+
+namespace ChaoVis {
+
+/**
+ * @brief Class to manage execution of command-line tools
+ */
+class CommandLineToolRunner : public QObject
+{
+    Q_OBJECT
+
+public:
+
+    explicit CommandLineToolRunner(QStatusBar* statusBar, QObject* parent = nullptr);
+    
+    ~CommandLineToolRunner();
+
+    enum class Tool {
+        RenderTifXYZ,
+        GrowSegFromSegment,
+        GrowSegFromSeeds,
+        SegAddOverlap,
+        tifxyz2obj
+    };
+
+    void setVolumePath(const QString& path);
+    void setSegmentPath(const QString& path);
+    void setOutputPattern(const QString& pattern);
+
+    // tool specific params 
+    void setRenderParams(float scale, int resolution, int layers);
+    void setGrowParams(QString volumePath, QString tgtDir, QString jsonParams, int seed_x, int seed_y, int seed_z);
+    void setTraceParams(QString volumePath, QString srcDir, QString tgtDir, QString jsonParams, QString srcSegment);
+    void setAddOverlapParams(QString tgtDir, QString tifxyzPath);
+    void setToObjParams(QString tifxyzPath, QString objPath);
+
+    bool execute(Tool tool);
+    void cancel();
+    bool isRunning() const;
+
+signals:
+    void toolStarted(Tool tool, const QString& message);
+    void toolFinished(Tool tool, bool success, const QString& message, const QString& outputPath, bool copyToClipboard = false);
+
+private slots:
+    void onProcessStarted();
+    void onProcessFinished(int exitCode, QProcess::ExitStatus exitStatus);
+    void onProcessError(QProcess::ProcessError error);
+
+private:
+    QStringList buildArguments(Tool tool);
+    QString toolName(Tool tool) const;
+    QString getOutputPath() const;
+
+    ProgressUtil* _progressUtil;
+    
+    QProcess* _process;
+    
+    QString _volumePath;
+    QString _segmentPath;
+    QString _outputPattern;
+    QString _tgtDir;
+    QString _srcDir;
+    QString _srcSegment;
+    QString _tifxyzPath;
+    QString _objPath;
+    QString _jsonParams;
+    
+    float _scale;
+    int _resolution;
+    int _layers;
+    int _seed_x;
+    int _seed_y;
+    int _seed_z; 
+    
+    Tool _currentTool;
+};
+
+} // namespace ChaoVis

--- a/apps/VC3D/ProgressUtil.cpp
+++ b/apps/VC3D/ProgressUtil.cpp
@@ -1,0 +1,53 @@
+#include "ProgressUtil.hpp"
+
+namespace ChaoVis {
+
+ProgressUtil::ProgressUtil(QStatusBar* statusBar, QObject* parent)
+    : QObject(parent)
+    , _statusBar(statusBar)
+    , _animTimer(nullptr)
+    , _animFrame(0)
+{
+}
+
+ProgressUtil::~ProgressUtil()
+{
+    if (_animTimer) {
+        if (_animTimer->isActive()) {
+            _animTimer->stop();
+        }
+        delete _animTimer;
+    }
+}
+
+void ProgressUtil::startAnimation(const QString& message)
+{
+
+    _animFrame = 0;
+    _message = message;
+    if (!_animTimer) {
+        _animTimer = new QTimer(this);
+        connect(_animTimer, &QTimer::timeout, this, &ProgressUtil::updateAnimation);
+    }
+    
+    _statusBar->showMessage(message + " |", 0); // 0 timeout means it stays until changed
+    _animTimer->start(300); // updates every 300 ms 
+}
+
+void ProgressUtil::stopAnimation(const QString& message, int timeout)
+{
+    if (_animTimer && _animTimer->isActive()) {
+        _animTimer->stop();
+    }
+    
+    _statusBar->showMessage(message, timeout);
+}
+
+void ProgressUtil::updateAnimation()
+{
+    static const QChar animChars[] = {'|', '/', '-', '\\'};
+    _animFrame = (_animFrame + 1) % 4;
+    _statusBar->showMessage(_message + " " + animChars[_animFrame], 0);
+}
+
+} // namespace ChaoVis

--- a/apps/VC3D/ProgressUtil.hpp
+++ b/apps/VC3D/ProgressUtil.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <QObject>
+#include <QStatusBar>
+#include <QTimer>
+#include <QString>
+
+namespace ChaoVis {
+
+class ProgressUtil : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ProgressUtil(QStatusBar* statusBar, QObject* parent = nullptr);
+    
+    ~ProgressUtil();
+
+    /**
+     * @brief Start a progress animation in the status bar
+     * @param message The message to display alongside the animation
+     */
+    void startAnimation(const QString& message);
+    
+    /**
+     * @brief Stop the progress animation and display a final message
+     * @param message The final message to display
+     * @param timeout How long to display the message (in ms, 0 for indefinite)
+     */
+    void stopAnimation(const QString& message, int timeout = 15000);
+
+private slots:
+    void updateAnimation();
+
+private:
+    QStatusBar* _statusBar;
+    QTimer* _animTimer;
+    int _animFrame;
+    QString _message;
+};
+
+} // namespace ChaoVis

--- a/apps/VC3D/SegmentRenderThread.cpp
+++ b/apps/VC3D/SegmentRenderThread.cpp
@@ -67,7 +67,9 @@ void SegmentRenderThread::run()
     connect(m_process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
             [this](int exitCode, QProcess::ExitStatus exitStatus) {
                 if (exitCode == 0 && exitStatus == QProcess::NormalExit) {
-                    emit renderingFinished("Segment rendering completed successfully");
+                    QFileInfo outputInfo(m_outputPattern);
+                    QDir outputDir = outputInfo.dir();
+                    emit renderingFinished("Segment rendering completed successfully", outputDir.path());
                 } else {
                     emit renderingFailed("Rendering process failed with exit code: " + QString::number(exitCode));
                 }

--- a/apps/VC3D/SegmentRenderThread.hpp
+++ b/apps/VC3D/SegmentRenderThread.hpp
@@ -25,7 +25,7 @@ public:
 
 signals:
     void renderingStarted(const QString& message);
-    void renderingFinished(const QString& message);
+    void renderingFinished(const QString& message, const QString& outputPath);
     void renderingFailed(const QString& errorMessage);
 
 private:


### PR DESCRIPTION
add some components/classes for running cmd line tools  and displaying progress (very basic so far) 

ProgressUtil
- reusable utility for displaying animated progress indicators in the status bar. handles start/stop animations , status bar messaging

CommandLineToolRunner
- supports for multiple vc3d command line tools
- progress and error reporting
- clipboard functionality for specific tools (like vc_render_tifxyz)

to add addtl tools. update the enum 

```cpp
enum class Tool {
    // Existing tools...
    YourNewTool
};
```

- __Add Parameter-Setting Method__:

  ```cpp
  void setYourNewToolParams(QString param1, int param2, ...) {
      _param1 = param1;
      _param2 = param2;
      // Set other parameters as needed
  }
  ```

- __Add Class Members__ for the new parameters if needed:

  ```cpp
  QString _param1;
  int _param2;
  ```

- __Update buildArguments__ to handle the new tool:

  ```cpp
  case Tool::YourNewTool:
      args << _param1
           << QString::number(_param2);
      break;
  ```

- __Update toolName__ to return the executable name:

  ```cpp
  case Tool::YourNewTool:
      return "vc_your_new_tool";
  ```

- __Usage__ from calling code:

  ```cpp
  _cmdRunner->setYourNewToolParams("value1", 42, ...);
  _cmdRunner->execute(CommandLineToolRunner::Tool::YourNewTool);
  ```



