### PR TITLE
Catch trace exceptions + auto delete debug folders + properly write `auto_trace_` folder

### DIFF
--- a/apps/src/vc_grow_seg_from_segments.cpp
+++ b/apps/src/vc_grow_seg_from_segments.cpp
@@ -175,8 +175,7 @@ int main(int argc, char *argv[])
 
     (*surf->meta)["source"] = "vc_grow_seg_from_segments";
     (*surf->meta)["vc_grow_seg_from_segments_params"] = params;
-    // std::string uuid = "testing_auto_surf_trace" + std::string("_opt_int_64%6_") + time_str();
-    std::string uuid = "auto_surf_trace_";
+    std::string uuid = "auto_trace_" + time_str();;
     fs::path seg_dir = tgt_dir / uuid;
     surf->save(seg_dir, uuid);
 

--- a/apps/src/vc_grow_seg_from_segments.cpp
+++ b/apps/src/vc_grow_seg_from_segments.cpp
@@ -127,6 +127,17 @@ int main(int argc, char *argv[])
     SurfaceMeta *src = new SurfaceMeta(src_path, meta);
     src->readOverlapping();
 
+    // Remove debug output folders from previous runs
+    std::string debug_prefix = Z_DBG_GEN_PREFIX;
+    for (const auto& entry : fs::directory_iterator(tgt_dir)) {
+        if (fs::is_directory(entry)) {
+            std::string name = entry.path().filename();
+            if (name.compare(0, debug_prefix.size(), debug_prefix) == 0) {
+                std::filesystem::remove_all(entry.path());
+            }
+        }
+    }
+
     for (const auto& entry : fs::directory_iterator(src_dir))
         if (fs::is_directory(entry)) {
             std::string name = entry.path().filename();

--- a/core/include/vc/core/util/Surface.hpp
+++ b/core/include/vc/core/util/Surface.hpp
@@ -7,6 +7,8 @@
 
 #include "SurfaceDef.hpp"
 
+#define Z_DBG_GEN_PREFIX "z_dbg_gen_"
+
 class QuadSurface;
 class ChunkCache;
 

--- a/core/src/Surface.cpp
+++ b/core/src/Surface.cpp
@@ -781,7 +781,6 @@ SurfacePointer *DeltaSurface::pointer()
     return _base->pointer();
 }
 
-
 void DeltaSurface::move(SurfacePointer *ptr, const cv::Vec3f &offset)
 {
     _base->move(ptr, offset);

--- a/core/src/SurfaceHelpers.cpp
+++ b/core/src/SurfaceHelpers.cpp
@@ -2452,7 +2452,7 @@ void optimize_surface_mapping(SurfTrackerData &data, cv::Mat_<uint8_t> &state, c
     cv::Mat_<uint8_t> fringe_next(state.size(), 1);
     int added = 1;
     for(int r=0;r<30 && added;r++) {
-        ALifeTime timer("add iteration\n");
+        ALifeTime timer("optimizer: add iteration\n");
         
         fringe_next.copyTo(fringe);
         fringe_next.setTo(0);

--- a/core/src/SurfaceHelpers.cpp
+++ b/core/src/SurfaceHelpers.cpp
@@ -2362,11 +2362,9 @@ void optimize_surface_mapping(SurfTrackerData &data, cv::Mat_<uint8_t> &state, c
     
     {
         cv::Mat_<cv::Vec3d> points_hr_inp = surftrack_genpoints_hr(data, new_state, points_inpainted, used_area, step, src_step, true);
-        cv::Mat3d roiMat;
         try {
-            roiMat = points_hr_inp(used_area_hr);
-            QuadSurface *dbg_surf = new QuadSurface(roiMat, {1/src_step,1/src_step});
-            std::string uuid = "z_dbg_gen_"+strint(dbg_counter, 5)+"_inp_hr";
+            QuadSurface *dbg_surf = new QuadSurface(points_hr_inp(used_area_hr), {1/src_step,1/src_step});
+            std::string uuid = Z_DBG_GEN_PREFIX+strint(dbg_counter, 5)+"_inp_hr";
             dbg_surf->save(tgt_dir / uuid, uuid);
             delete dbg_surf;
         } catch (cv::Exception) {
@@ -2533,11 +2531,9 @@ void optimize_surface_mapping(SurfTrackerData &data, cv::Mat_<uint8_t> &state, c
             
     {
         cv::Mat_<cv::Vec3d> points_hr_inp = surftrack_genpoints_hr(data, state, points, used_area, step, src_step, true);
-        cv::Mat3d roiMat;
         try {
-            roiMat = points_hr_inp(used_area_hr);
-            QuadSurface *dbg_surf = new QuadSurface(roiMat, {1/src_step,1/src_step});
-            std::string uuid = "z_dbg_gen_"+strint(dbg_counter, 5)+"_opt_inp_hr";
+            QuadSurface *dbg_surf = new QuadSurface(points_hr_inp(used_area_hr), {1/src_step,1/src_step});
+            std::string uuid = Z_DBG_GEN_PREFIX+strint(dbg_counter, 5)+"_opt_inp_hr";
             dbg_surf->save(tgt_dir / uuid, uuid);
             delete dbg_surf;
         } catch (cv::Exception) {
@@ -3067,7 +3063,7 @@ QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMe
                 QuadSurface *dbg_surf = new QuadSurface(points_hr(used_area_hr), {1/src_step,1/src_step});
                 dbg_surf->meta = new nlohmann::json;
                 (*dbg_surf->meta)["vc_grow_seg_from_segments_params"] = params;
-                std::string uuid = "z_dbg_gen_"+strint(generation, 5);
+                std::string uuid = Z_DBG_GEN_PREFIX+strint(generation, 5);
                 dbg_surf->save(tgt_dir / uuid, uuid);
                 delete dbg_surf;
             }
@@ -3106,7 +3102,7 @@ QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMe
             {
                 cv::Mat_<cv::Vec3d> points_hr = surftrack_genpoints_hr(data, state, points, used_area, step, src_step);
                 QuadSurface *dbg_surf = new QuadSurface(points_hr(used_area_hr), {1/src_step,1/src_step});
-                std::string uuid = "z_dbg_gen_"+strint(generation, 5)+"_opt";
+                std::string uuid = Z_DBG_GEN_PREFIX+strint(generation, 5)+"_opt";
                 dbg_surf->save(tgt_dir / uuid, uuid);
                 delete dbg_surf;
             }
@@ -3167,7 +3163,7 @@ QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMe
 
     cv::Mat_<cv::Vec3d> points_hr = surftrack_genpoints_hr(data, state, points, used_area, step, src_step);
 
-    QuadSurface *surf = new QuadSurface(points_hr(used_area), {1/src_step,1/src_step});
+    QuadSurface *surf = new QuadSurface(points_hr(used_area_hr), {1/src_step,1/src_step});
 
     surf->meta = new nlohmann::json;
 


### PR DESCRIPTION
Relevant for `vc_grow_seg_from_segments`

**Fixes:**
- Catch `cv::Exception` when the optimizer does not find a valid ROI any longer + output to CMD
- Add timestamp to generated `auto_trace_` folder
- Ensure that the actual outcome of the trace gets properly written into that folder (previously just tiny and empty TIF files)
- Write `inliers_sum.tif` file to target directory rather than the location of the binary EXE

**Features:**
- Automatically remove all debug folders (`z_dgb_gen_`) from previous runs. If that is too aggressive I can add a CMD option.