### PR TITLE
Fix memory leaks during trace generation (`vc_grow_seg_from_segments`)

### DIFF
--- a/apps/src/vc_grow_seg_from_segments.cpp
+++ b/apps/src/vc_grow_seg_from_segments.cpp
@@ -179,5 +179,10 @@ int main(int argc, char *argv[])
     fs::path seg_dir = tgt_dir / uuid;
     surf->save(seg_dir, uuid);
 
+    delete surf;
+    for(auto sm : surfaces) {
+        delete sm;
+    }
+
     return EXIT_SUCCESS;
 }

--- a/core/include/vc/core/util/Surface.hpp
+++ b/core/include/vc/core/util/Surface.hpp
@@ -52,6 +52,8 @@ cv::Vec3f vy_from_orig_norm(const cv::Vec3f &o, const cv::Vec3f &n);
 class Surface
 {
 public:
+    virtual ~Surface();
+
     // a pointer in some central location
     virtual SurfacePointer *pointer() = 0;
     
@@ -77,7 +79,7 @@ class PlaneSurface : public Surface
 {
 public:
     //Surface API FIXME
-    SurfacePointer *pointer() override;
+    TrivialSurfacePointer *pointer() override;
     void move(SurfacePointer *ptr, const cv::Vec3f &offset);
     bool valid(SurfacePointer *ptr, const cv::Vec3f &offset = {0,0,0}) override { return true; };
     cv::Vec3f loc(SurfacePointer *ptr, const cv::Vec3f &offset = {0,0,0}) override;
@@ -108,7 +110,7 @@ protected:
 class QuadSurface : public Surface
 {
 public:
-    SurfacePointer *pointer();
+    TrivialSurfacePointer *pointer();
     QuadSurface() {};
     QuadSurface(const cv::Mat_<cv::Vec3f> &points, const cv::Vec2f &scale);
     void move(SurfacePointer *ptr, const cv::Vec3f &offset) override;
@@ -210,6 +212,7 @@ public:
     SurfaceMeta() {};
     SurfaceMeta(const std::filesystem::path &path_, const nlohmann::json &json);
     SurfaceMeta(const std::filesystem::path &path_);
+    ~SurfaceMeta();
     void readOverlapping();
     QuadSurface *surface();
     void setSurface(QuadSurface *surf);
@@ -217,7 +220,7 @@ public:
     std::filesystem::path path;
     QuadSurface *_surf = nullptr;
     Rect3D bbox;
-    nlohmann::json *meta;
+    nlohmann::json *meta = nullptr;
     std::set<std::string> overlapping_str;
     std::set<SurfaceMeta*> overlapping;
 };

--- a/core/src/SurfaceHelpers.cpp
+++ b/core/src/SurfaceHelpers.cpp
@@ -2420,7 +2420,7 @@ void optimize_surface_mapping(SurfTrackerData &data, cv::Mat_<uint8_t> &state, c
                     surfs.insert(data.surfsC({y+1,x+1}).begin(), data.surfsC({y+1,x+1}).end());
                     
                     for(auto &s : surfs) {
-                        SurfacePointer *ptr = s->surface()->pointer();
+                        auto *ptr = s->surface()->pointer();
                         float res = s->surface()->pointTo(ptr, points_out(j, i), same_surface_th, 10);
                         if (res <= same_surface_th) {
                             mutex.lock();
@@ -2429,6 +2429,7 @@ void optimize_surface_mapping(SurfTrackerData &data, cv::Mat_<uint8_t> &state, c
                             data_out.loc(s, {j,i}) = {loc[1], loc[0]};
                             mutex.unlock();
                         }
+                        delete ptr;
                     }
                 }
             }
@@ -2476,12 +2477,13 @@ void optimize_surface_mapping(SurfTrackerData &data, cv::Mat_<uint8_t> &state, c
                         }
                         mutex.unlock();
                         
-                        SurfacePointer *ptr = test_surf->surface()->pointer();
+                        auto *ptr = test_surf->surface()->pointer();
                         if (test_surf->surface()->pointTo(ptr, points_out(j, i), same_surface_th, 10) > same_surface_th)
                             continue;
                         
                         int count = 0;
                         cv::Vec3f loc_3d = test_surf->surface()->loc_raw(ptr);
+                        delete ptr;
                         int straight_count = 0;
                         float cost;
                         mutex.lock();
@@ -2543,9 +2545,6 @@ void optimize_surface_mapping(SurfTrackerData &data, cv::Mat_<uint8_t> &state, c
     }
             
     dbg_counter++;
-    
-    delete sm_inp._surf;
-    delete sm._surf;
 }
 
 QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMeta*> &surfs_v, const nlohmann::json &params)
@@ -2671,12 +2670,13 @@ QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMe
         cv::Vec3f coord = points(p);
         std::cout << "testing " << p << " from cands: " << seed->overlapping.size() << coord << std::endl;
         for(auto s : seed->overlapping) {
-            SurfacePointer *ptr = s->surface()->pointer();
+            auto *ptr = s->surface()->pointer();
             if (s->surface()->pointTo(ptr, coord, same_surface_th) <= same_surface_th) {
                 cv::Vec3f loc = s->surface()->loc_raw(ptr);
                 data.surfs(p).insert(s);
                 data.loc(s, p) = {loc[1], loc[0]};
             }
+            delete ptr;
         }
         std::cout << "fringe point " << p << " surfcount " << data.surfs(p).size() << " init " << data.loc(seed, p) << data.lookup_int(seed, p) << std::endl;
     }
@@ -2850,7 +2850,7 @@ QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMe
                 }
 
                 for(auto test_surf : local_surfs) {
-                    SurfacePointer *ptr = test_surf->surface()->pointer();
+                    auto *ptr = test_surf->surface()->pointer();
                     //FIXME this does not check geometry, only if its also on the surfaces (which might be good enough...)
                     if (test_surf->surface()->pointTo(ptr, coord, same_surface_th, 10) <= same_surface_th) {
                         int count = 0;
@@ -2866,6 +2866,7 @@ QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMe
                             inliers_count++;
                         }
                     }
+                    delete ptr;
                 }
                 if ((inliers_count >= 2 || ref_seed) && inliers_sum > best_inliers) {
                     best_inliers = inliers_sum;
@@ -2918,7 +2919,7 @@ QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMe
                     if (test_surf == best_surf)
                         continue;
                     
-                    SurfacePointer *ptr = test_surf->surface()->pointer();
+                    auto *ptr = test_surf->surface()->pointer();
                     if (test_surf->surface()->pointTo(ptr, best_coord, same_surface_th, 10) <= same_surface_th) {
                         cv::Vec3f loc = test_surf->surface()->loc_raw(ptr);
                         data_th.loc(test_surf, p) = {loc[1], loc[0]};
@@ -2932,6 +2933,7 @@ QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMe
                         else
                             data_th.erase(test_surf, p);
                     }
+                    delete ptr;
                 }
                 
                 ceres::Solver::Summary summary;
@@ -2940,7 +2942,7 @@ QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMe
                 
                 //TODO only add/test if we have 2 neighs which both find locations
                 for(auto test_surf : more_local_surfs) {
-                    SurfacePointer *ptr = test_surf->surface()->pointer();
+                    auto *ptr = test_surf->surface()->pointer();
                     float res = test_surf->surface()->pointTo(ptr, best_coord, same_surface_th, 10);
                     if (res <= same_surface_th) {
                         cv::Vec3f loc = test_surf->surface()->loc_raw(ptr);
@@ -2955,6 +2957,7 @@ QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMe
                             data_th.surfs(p).insert(test_surf);
                         };
                     }
+                    delete ptr;
                 }
                 
                 mutex.lock();

--- a/core/src/SurfaceHelpers.cpp
+++ b/core/src/SurfaceHelpers.cpp
@@ -2031,7 +2031,7 @@ int surftrack_add_global(SurfaceMeta *sm, const cv::Vec2i p, SurfTrackerData &da
     if (flags & LOSS_ON_SURF)
     {
         if (step_onsurf == 0)
-            throw std::runtime_error("oops");
+            throw std::runtime_error("oops step_onsurf == 0");
         
         //direct
         count += cond_surftrack_distloss(8, sm, p, {0,1}, data, problem, state, step_onsurf);
@@ -2746,7 +2746,7 @@ QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMe
                 continue;
             
             if (points(p)[0] != -1)
-                throw std::runtime_error("oops");
+                throw std::runtime_error("oops points(p)[0]");
 
             std::set<SurfaceMeta*> local_surfs = {seed};
             


### PR DESCRIPTION
Fixes #16. `valgrind` logs from a small run so I could quickly iterate.

**Before:**
```
==1280613== LEAK SUMMARY:
==1280613==    definitely lost: 11,064 bytes in 98 blocks
==1280613==    indirectly lost: 971,917 bytes in 6,642 blocks
==1280613==      possibly lost: 908,859 bytes in 175 blocks
==1280613==    still reachable: 58,472,707 bytes in 534,475 blocks
==1280613==         suppressed: 0 bytes in 0 blocks
==1280613== Reachable blocks (those to which a pointer was found) are not shown.
==1280613== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==1280613== 
==1280613== For lists of detected and suppressed errors, rerun with: -s
==1280613== ERROR SUMMARY: 81 errors from 81 contexts (suppressed: 0 from 0)
```

**After:**
```
==1266097== LEAK SUMMARY:
==1266097==    definitely lost: 0 bytes in 0 blocks
==1266097==    indirectly lost: 0 bytes in 0 blocks
==1266097==      possibly lost: 6,160 bytes in 11 blocks
==1266097==    still reachable: 663,403 bytes in 3,976 blocks
==1266097==         suppressed: 0 bytes in 0 blocks
==1266097== Reachable blocks (those to which a pointer was found) are not shown.
==1266097== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==1266097== 
==1266097== For lists of detected and suppressed errors, rerun with: -s
==1266097== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

The remaining "possibly lost" one is coming from the `GOMP_parallel` and most likely a false positive, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=36298