### PR TITLE
Performance optimizations for surface loading + VC3D memory leaks

### DIFF
--- a/apps/VC3D/CSurfaceCollection.cpp
+++ b/apps/VC3D/CSurfaceCollection.cpp
@@ -1,8 +1,24 @@
 #include "CSurfaceCollection.hpp"
 
 #include "vc/core/util/Slicing.hpp"
+#include "vc/core/util/Surface.hpp"
 
 using namespace ChaoVis;
+
+CSurfaceCollection::~CSurfaceCollection()
+{
+    for (auto& pair : _surfs) {
+        delete pair.second;
+    }
+
+    for (auto& pair : _pois) {
+        delete pair.second;
+    }
+
+    for (auto& pair : _intersections) {
+        delete pair.second;
+    }
+}
 
 void CSurfaceCollection::setSurface(const std::string &name, Surface* surf, bool noSignalSend)
 {

--- a/apps/VC3D/CSurfaceCollection.hpp
+++ b/apps/VC3D/CSurfaceCollection.hpp
@@ -40,6 +40,7 @@ class CSurfaceCollection : public QObject
     Q_OBJECT
     
 public:
+    ~CSurfaceCollection();
     void setSurface(const std::string &name, Surface*, bool noSignalSend = false);
     void setPOI(const std::string &name, POI *poi);
     void setIntersection(const std::string &a, const std::string &b, Intersection *intersect);

--- a/apps/VC3D/CWindow.cpp
+++ b/apps/VC3D/CWindow.cpp
@@ -123,6 +123,8 @@ CWindow::CWindow() :
 CWindow::~CWindow(void)
 {
     CloseVolume();
+    delete chunk_cache;
+    delete _surf_col;
 }
 
 CVolumeViewer *CWindow::newConnectedCVolumeViewer(std::string surfaceName, QString title, QMdiArea *mdiArea)
@@ -603,6 +605,8 @@ void CWindow::OpenRecent()
 
 void CWindow::LoadSurfaces(bool reload)
 {
+    std::cout << "Start of loading surfaces..." << std::endl;
+
     if (reload && !InitializeVolumePkg(fVpkgPath.toStdString() + "/")) {
         return;
     }
@@ -659,6 +663,8 @@ void CWindow::LoadSurfaces(bool reload)
             treeWidgetSurfaces->setCurrentItem(item);
         }
     }
+
+    std::cout << "Loading of surfaces completed." << std::endl;
 }
 
 // Pop up about dialog

--- a/apps/src/vc_render_tifxyz.cpp
+++ b/apps/src/vc_render_tifxyz.cpp
@@ -143,14 +143,13 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    cv::Mat_<cv::Vec3f> raw_points = surf->rawPoints();
-    for(int j=0;j<raw_points.rows;j++)
-        for(int i=0;i<raw_points.cols;i++)
-            if (raw_points(j,i)[0] == -1)
-                raw_points(j,i) = {NAN,NAN,NAN};
-    surf->setRawPoints(raw_points);
+    cv::Mat_<cv::Vec3f> *raw_points = surf->rawPointsPtr();
+    for(int j=0;j<raw_points->rows;j++)
+        for(int i=0;i<raw_points->cols;i++)
+            if ((*raw_points)(j,i)[0] == -1)
+                (*raw_points)(j,i) = {NAN,NAN,NAN};
     
-    cv::Size full_size = raw_points.size();
+    cv::Size full_size = raw_points->size();
     full_size.width *= tgt_scale/surf->_scale[0];
     full_size.height *= tgt_scale/surf->_scale[1];
     
@@ -215,7 +214,6 @@ int main(int argc, char *argv[])
             cv::imwrite(buf, img);
         }
     }
-
 
     return EXIT_SUCCESS;
 }

--- a/apps/src/vc_tifxyz_inp_mask.cpp
+++ b/apps/src/vc_tifxyz_inp_mask.cpp
@@ -32,13 +32,13 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    cv::Mat_<cv::Vec3f> points = surf->rawPoints();
+    cv::Mat_<cv::Vec3f> *points = surf->rawPointsPtr();
     cv::Mat_<uint8_t> mask = cv::imread(mask_path, cv::IMREAD_GRAYSCALE);
     cv::Mat_<uint8_t> mask_points(mask.size(), 0);
 
-    for(int j=0;j<points.rows;j++)
-        for(int i=0;i<points.cols;i++)
-            if (points(j,i)[0] == -1)
+    for(int j=0;j<points->rows;j++)
+        for(int i=0;i<points->cols;i++)
+            if ((*points)(j,i)[0] == -1)
                 mask_points(j,i) = 1;
 
     //closing operation to skip 1-2 pixel holes
@@ -49,23 +49,22 @@ int main(int argc, char *argv[])
     for(int r=0;r<12;r++)
         cv::dilate(mask_points, mask_points, m, {-1,-1}, 1);
 
-    std::cout << "sizes " << points.size() << mask.size() << std::endl;
-    if (mask.size() != points.size())
+    std::cout << "sizes " << points->size() << mask.size() << std::endl;
+    if (mask.size() != points->size())
         throw std::runtime_error("mask must be same size as tiffxyz");
 
     cv::erode(mask, mask, m, {-1,-1}, 1);
 
-    cv::Mat_<cv::Vec3f> points_orig = points.clone();
+    cv::Mat_<cv::Vec3f> points_orig = points->clone();
 
     for(int r=0;r<100;r++) {
         int dia = int(float(100-r)/100*11)*2+1;
         std::cout << dia << std::endl;
-        cv::GaussianBlur(points, points, {dia,dia}, 0);
-        points_orig.copyTo(points, mask);
+        cv::GaussianBlur((*points), (*points), {dia,dia}, 0);
+        points_orig.copyTo((*points), mask);
     }
-    points.setTo(cv::Vec3f(-1,-1,-1), mask_points);
+    points->setTo(cv::Vec3f(-1,-1,-1), mask_points);
 
-    surf->setRawPoints(points);
     surf->save(tgt_path);
     
     return EXIT_SUCCESS;

--- a/core/include/vc/core/util/Surface.hpp
+++ b/core/include/vc/core/util/Surface.hpp
@@ -112,7 +112,11 @@ class QuadSurface : public Surface
 public:
     TrivialSurfacePointer *pointer();
     QuadSurface() {};
+    // points will be cloned in constructor
     QuadSurface(const cv::Mat_<cv::Vec3f> &points, const cv::Vec2f &scale);
+    // points will not be cloned in constructor, but pointer stored
+    QuadSurface(cv::Mat_<cv::Vec3f> *points, const cv::Vec2f &scale);
+    ~QuadSurface();
     void move(SurfacePointer *ptr, const cv::Vec3f &offset) override;
     bool valid(SurfacePointer *ptr, const cv::Vec3f &offset = {0,0,0}) override;
     cv::Vec3f loc(SurfacePointer *ptr, const cv::Vec3f &offset = {0,0,0}) override;
@@ -127,15 +131,15 @@ public:
     void save_meta();
     Rect3D bbox();
 
-    virtual cv::Mat_<cv::Vec3f> rawPoints() { return _points; }
-    virtual void setRawPoints(cv::Mat_<cv::Vec3f> points) { _points = points; }
+    virtual cv::Mat_<cv::Vec3f> rawPoints() { return *_points; }
+    virtual cv::Mat_<cv::Vec3f> *rawPointsPtr() { return _points; }
 
     friend QuadSurface *regularized_local_quad(QuadSurface *src, SurfacePointer *ptr, int w, int h, int step_search, int step_out);
     friend QuadSurface *smooth_vc_segmentation(QuadSurface *src);
     friend class ControlPointSurface;
     cv::Vec2f _scale;
 protected:
-    cv::Mat_<cv::Vec3f> _points;
+    cv::Mat_<cv::Vec3f>* _points = nullptr;
     cv::Rect _bounds;
     cv::Vec3f _center;
     Rect3D _bbox = {{-1,-1,-1},{-1,-1,-1}};

--- a/core/src/Surface.cpp
+++ b/core/src/Surface.cpp
@@ -1508,17 +1508,13 @@ SurfaceMeta::~SurfaceMeta()
     if (meta) {
         delete meta;
     }
-
-    overlapping_str.clear();
 }
 
 void SurfaceMeta::readOverlapping()
 {
     if (std::filesystem::exists(path / "overlapping"))
-        for (const auto& entry : fs::directory_iterator(path / "overlapping")) {
-            auto filename = entry.path().filename();
-            overlapping_str.insert(filename);
-        }
+        for (const auto& entry : fs::directory_iterator(path / "overlapping"))
+            overlapping_str.insert(entry.path().filename());
 }
 
 QuadSurface *SurfaceMeta::surface()

--- a/core/src/Surface.cpp
+++ b/core/src/Surface.cpp
@@ -238,19 +238,30 @@ cv::Vec3f PlaneSurface::normal(SurfacePointer *ptr, const cv::Vec3f &offset)
     return _normal;
 }
 
-//TODO add non-cloning variant?
-QuadSurface::QuadSurface(const cv::Mat_<cv::Vec3f> &points, const cv::Vec2f &scale)
+QuadSurface::QuadSurface(const cv::Mat_<cv::Vec3f> &points, const cv::Vec2f &scale) : 
+    QuadSurface(new cv::Mat_<cv::Vec3f>(points.clone()), scale)
 {
-    _points = points.clone();
+}
+
+QuadSurface::QuadSurface(cv::Mat_<cv::Vec3f> *points, const cv::Vec2f &scale)
+{
+    _points = points;
     //-1 as many times we read with linear interpolation and access +1 locations
-    _bounds = {0,0,points.cols-1,points.rows-1};
+    _bounds = {0,0,_points->cols-1,_points->rows-1};
     _scale = scale;
-    _center = {points.cols/2.0/_scale[0],points.rows/2.0/_scale[1],0};
+    _center = {_points->cols/2.0/_scale[0],_points->rows/2.0/_scale[1],0};
+}
+
+QuadSurface::~QuadSurface()
+{
+    if (_points) {
+        delete _points;
+    }
 }
 
 QuadSurface *smooth_vc_segmentation(QuadSurface *src)
 {
-    cv::Mat_<cv::Vec3f> points = smooth_vc_segmentation(src->_points);
+    cv::Mat_<cv::Vec3f> points = smooth_vc_segmentation(src->rawPoints());
     
     double sx, sy;
     vc_segmentation_scales(points, sx, sy);
@@ -286,11 +297,11 @@ cv::Vec3f QuadSurface::coord(SurfacePointer *ptr, const cv::Vec3f &offset)
     assert(ptr_inst);
     cv::Vec3f p = internal_loc(offset+_center, ptr_inst->loc, _scale);
 
-    cv::Rect bounds = {0,0,_points.cols-2,_points.rows-2};
+    cv::Rect bounds = {0,0,_points->cols-2,_points->rows-2};
     if (!bounds.contains(cv::Point(p[0],p[1])))
         return {-1,-1,-1};
         
-    return at_int(_points, {p[0],p[1]});
+    return at_int((*_points), {p[0],p[1]});
 }
 
 cv::Vec3f QuadSurface::loc(SurfacePointer *ptr, const cv::Vec3f &offset)
@@ -315,7 +326,7 @@ cv::Vec3f QuadSurface::normal(SurfacePointer *ptr, const cv::Vec3f &offset)
     assert(ptr_inst);
     cv::Vec3f p = internal_loc(offset+_center, ptr_inst->loc, _scale);
     
-    return grid_normal(_points, p);
+    return grid_normal((*_points), p);
 }
 
 static inline float sdist(const cv::Vec3f &a, const cv::Vec3f &b)
@@ -605,10 +616,10 @@ float QuadSurface::pointTo(SurfacePointer *ptr, const cv::Vec3f &tgt, float th, 
     cv::Vec3f _out;
     
     cv::Vec2f step_small = {std::max(1.0f,_scale[0]),std::max(1.0f,_scale[1])};
-    float min_mul = std::min(0.1*_points.cols/_scale[0],0.1*_points.rows/_scale[1]);
+    float min_mul = std::min(0.1*_points->cols/_scale[0],0.1*_points->rows/_scale[1]);
     cv::Vec2f step_large = {min_mul*_scale[0],min_mul*_scale[1]};
 
-    float dist = search_min_loc(_points, loc, _out, tgt, step_small, _scale[0]*0.1);
+    float dist = search_min_loc(*_points, loc, _out, tgt, step_small, _scale[0]*0.1);
     
     if (dist < th && dist >= 0) {
         tgt_ptr->loc = cv::Vec3f(loc[0],loc[1],0) - cv::Vec3f(_center[0]*_scale[0],_center[1]*_scale[1],0);
@@ -618,21 +629,21 @@ float QuadSurface::pointTo(SurfacePointer *ptr, const cv::Vec3f &tgt, float th, 
     cv::Vec2f min_loc = loc;
     float min_dist = dist;
     if (min_dist < 0)
-        min_dist = 10*(_points.cols/_scale[0]+_points.rows/_scale[1]);
+        min_dist = 10*(_points->cols/_scale[0]+_points->rows/_scale[1]);
     
     int r_full = 0;
     for(int r=0;r<10*max_iters && r_full < max_iters;r++) {
-        loc = {1 + (rand() % (_points.cols-3)), 1 + (rand() % (_points.rows-3))};
+        loc = {1 + (rand() % (_points->cols-3)), 1 + (rand() % (_points->rows-3))};
         
-        if (_points(loc[1],loc[0])[0] == -1)
+        if ((*_points)(loc[1],loc[0])[0] == -1)
             continue;
         
         r_full++;
 
-        float dist = search_min_loc(_points, loc, _out, tgt, step_large, _scale[0]*0.1);
+        float dist = search_min_loc(*_points, loc, _out, tgt, step_large, _scale[0]*0.1);
         
         if (dist < th && dist >= 0) {
-            dist = search_min_loc(_points, loc, _out, tgt, step_small, _scale[0]*0.1);
+            dist = search_min_loc((*_points), loc, _out, tgt, step_small, _scale[0]*0.1);
             tgt_ptr->loc = cv::Vec3f(loc[0],loc[1],0) - cv::Vec3f(_center[0]*_scale[0],_center[1]*_scale[1],0);
             return dist;
         } else if (dist >= 0 && dist < min_dist) {
@@ -747,7 +758,7 @@ void QuadSurface::gen(cv::Mat_<cv::Vec3f> *coords, cv::Mat_<cv::Vec3f> *normals,
     std::vector<cv::Vec2f> src = {off2d,off2d+cv::Vec2f((w+8)*_scale[0]/scale,0),off2d+cv::Vec2f(0,(h+8)*_scale[1]/scale)};
     
     cv::Mat affine = cv::getAffineTransform(src, dst);
-    cv::warpAffine(_points, *coords, affine, size+cv::Size(8,8));
+    cv::warpAffine(*_points, *coords, affine, size+cv::Size(8,8));
     
     //TODO create normals directly from input points instead off on sampled output ...
     if (create_normals) {
@@ -1301,7 +1312,7 @@ void QuadSurface::save(const std::string &path_, const std::string &uuid)
 
     std::vector<cv::Mat> xyz;
 
-    cv::split(_points, xyz);
+    cv::split((*_points), xyz);
 
     cv::imwrite(path/"x.tif", xyz[0]);
     cv::imwrite(path/"y.tif", xyz[1]);
@@ -1339,16 +1350,15 @@ void QuadSurface::save_meta()
 Rect3D QuadSurface::bbox()
 {
     if (_bbox.low[0] == -1) {
-        _bbox.low = _points(0,0);
-        _bbox.high = _points(0,0);
+        _bbox.low = (*_points)(0,0);
+        _bbox.high = (*_points)(0,0);
 
-        for(int j=0;j<_points.rows;j++)
-            for(int i=0;i<_points.cols;i++)
-                for(int c=0;c<3;c++)
-                    if (_bbox.low[0] == -1)
-                        _bbox = {_points(j,i),_points(j,i)};
-                    else if (_points(j,i)[0] != -1)
-                        _bbox = expand_rect(_bbox, _points(j,i));
+        for(int j=0;j<_points->rows;j++)
+            for(int i=0;i<_points->cols;i++)
+                if (_bbox.low[0] == -1)
+                    _bbox = {(*_points)(j,i),(*_points)(j,i)};
+                else if ((*_points)(j,i)[0] != -1)
+                    _bbox = expand_rect(_bbox, (*_points)(j,i));
     }
 
     return _bbox;
@@ -1358,30 +1368,30 @@ QuadSurface *load_quad_from_tifxyz(const std::string &path)
 {
     std::vector<cv::Mat_<float>> xyz = {cv::imread(path+"/x.tif",cv::IMREAD_UNCHANGED),cv::imread(path+"/y.tif",cv::IMREAD_UNCHANGED),cv::imread(path+"/z.tif",cv::IMREAD_UNCHANGED)};
 
-    cv::Mat_<cv::Vec3f> points;
-    cv::merge(xyz, points);
+    auto points = new cv::Mat_<cv::Vec3f>;
+    cv::merge(xyz, (*points));
 
     std::ifstream meta_f(path+"/meta.json");
     nlohmann::json metadata = nlohmann::json::parse(meta_f);
 
     cv::Vec2f scale = {metadata["scale"][0].get<float>(), metadata["scale"][1].get<float>()};
 
-    for(int j=0;j<points.rows;j++)
-        for(int i=0;i<points.cols;i++)
+    for(int j=0;j<points->rows;j++)
+        for(int i=0;i<points->cols;i++)
             //TODO fix this in the patch gen, also check bounds here in general!
-            if (points(j,i)[2] <= 0) {
-                points(j,i) = {-1,-1,-1};
+            if ((*points)(j,i)[2] <= 0) {
+                (*points)(j,i) = {-1,-1,-1};
             }
             
     if (fs::exists(path+"/mask.tif")) {
         std::vector<cv::Mat> layers;
         cv::imreadmulti(path+"/mask.tif", layers, cv::IMREAD_GRAYSCALE);
         cv::Mat_<uint8_t> mask = layers[0];
-        cv::resize(mask, mask, points.size(), cv::INTER_NEAREST);
-        for(int j=0;j<points.rows;j++)
-            for(int i=0;i<points.cols;i++)
+        cv::resize(mask, mask, points->size(), cv::INTER_NEAREST);
+        for(int j=0;j<points->rows;j++)
+            for(int i=0;i<points->cols;i++)
                 if (!mask(j,i))
-                    points(j,i) = {-1,-1,-1};
+                    (*points)(j,i) = {-1,-1,-1};
     }
     
     QuadSurface *surf = new QuadSurface(points, scale);
@@ -1498,13 +1508,17 @@ SurfaceMeta::~SurfaceMeta()
     if (meta) {
         delete meta;
     }
+
+    overlapping_str.clear();
 }
 
 void SurfaceMeta::readOverlapping()
 {
     if (std::filesystem::exists(path / "overlapping"))
-        for (const auto& entry : fs::directory_iterator(path / "overlapping"))
-            overlapping_str.insert(entry.path().filename());
+        for (const auto& entry : fs::directory_iterator(path / "overlapping")) {
+            auto filename = entry.path().filename();
+            overlapping_str.insert(filename);
+        }
 }
 
 QuadSurface *SurfaceMeta::surface()


### PR DESCRIPTION
Relates to #7

Improved surface loading performance. Using my test setup for scroll 5 with 38.000 surfaces, the loading portion (`CWindow::LoadSurfaces`) shrunk from 9 to 6 seconds (somewhat unscientific `std::time` timings).

**Main points:**
- For `QuadSurface` I introduced a new constructor that does not clone the `cv::Mat`. Most of the changes relate to this.
- Run `readOverlapping()` already in the OMP parallel portion rather than when building in a single thread the surface list tree widget.
- Removed weird extra nested loop in `QuadSurface::bbox()`

I also fixed most memory leaks in VC3D.