### PR TITLE
Fix QT_OBJECT surface tree issue for QT6.8 + add support for 25.04 and `vc3d.desktop`

### DIFF
--- a/apps/VC3D/CMakeLists.txt
+++ b/apps/VC3D/CMakeLists.txt
@@ -6,6 +6,7 @@ set(srcs
     VCAppMain.cpp
     CMesh.cpp
     CWindow.cpp
+    CWindowContextMenu.cpp
     UDataManipulateUtils.cpp
     CVolumeViewer.cpp
     CVolumeViewerView.cpp

--- a/apps/VC3D/CWindow.cpp
+++ b/apps/VC3D/CWindow.cpp
@@ -575,6 +575,7 @@ void CWindow::CloseVolume(void)
         delete pair.second;
     }
     _vol_qsurfs.clear();
+    _surf_col->setSurface("segmentation", nullptr, true);
 
     for (auto& pair : _opchains) {
         delete pair.second;
@@ -884,6 +885,9 @@ void CWindow::onTagChanged(void)
 
 void CWindow::onSurfaceSelected(QTreeWidgetItem *current, QTreeWidgetItem *previous)
 {
+    if (!current) {
+        return;
+    }
     _surfID = current->data(SURFACE_ID_COLUMN, Qt::UserRole).toString().toStdString();
 
     // Update sub window title with surface ID
@@ -1131,7 +1135,7 @@ void CWindow::onSurfaceContextMenuRequested(const QPoint& pos)
     });
     
     // Grow segment from segment action
-    QAction* growSegmentAction = new QAction(tr("Grow segment from segment"), this);
+    QAction* growSegmentAction = new QAction(tr("Run Trace / Grow segment"), this);
     connect(growSegmentAction, &QAction::triggered, [this, segmentId]() {
         onGrowSegmentFromSegment(segmentId);
     });
@@ -1149,370 +1153,40 @@ void CWindow::onSurfaceContextMenuRequested(const QPoint& pos)
     });
     
     // Seed submenu with options
-    QMenu* seedMenu = new QMenu(tr("Seed"), &contextMenu);
+    QMenu* seedMenu = new QMenu(tr("Run Seed"), &contextMenu);
     
     // Seed with Seed.json action
-    QAction* seedWithSeedAction = new QAction(tr("Seed"), seedMenu);
+    QAction* seedWithSeedAction = new QAction(tr("Seed from Focus Point"), seedMenu);
     connect(seedWithSeedAction, &QAction::triggered, [this, segmentId]() {
         onGrowSeeds(segmentId, false, false);
     });
     
     // Random Seed with Seed.json action
-    QAction* randomSeedAction = new QAction(tr("Random Seed"), seedMenu);
-    connect(randomSeedAction, &QAction::triggered, [this, segmentId]() {
+    QAction* seedWithRandomAction = new QAction(tr("Random Seed"), seedMenu);
+    connect(seedWithRandomAction, &QAction::triggered, [this, segmentId]() {
         onGrowSeeds(segmentId, false, true);
     });
     
     // Seed with Expand.json action
-    QAction* seedWithExpandAction = new QAction(tr("Expand"), seedMenu);
+    QAction* seedWithExpandAction = new QAction(tr("Expand Seed"), seedMenu);
     connect(seedWithExpandAction, &QAction::triggered, [this, segmentId]() {
         onGrowSeeds(segmentId, true, false);
     });
     
     seedMenu->addAction(seedWithSeedAction);
-    seedMenu->addAction(randomSeedAction);
+    seedMenu->addAction(seedWithRandomAction);
     seedMenu->addAction(seedWithExpandAction);
     
     // Add all actions to the context menu
-    contextMenu.addAction(renderAction);
+    contextMenu.addMenu(seedMenu);
     contextMenu.addAction(growSegmentAction);
     contextMenu.addAction(addOverlapAction);
-    contextMenu.addAction(convertToObjAction);
-    contextMenu.addMenu(seedMenu);
+    contextMenu.addSeparator();
+    contextMenu.addAction(renderAction);
+    contextMenu.addSeparator();
+    contextMenu.addAction(convertToObjAction);    
     
     // show the context menu at the position of the right-click
     contextMenu.exec(treeWidgetSurfaces->mapToGlobal(pos));
 }
 
-void CWindow::onRenderSegment(const SurfaceID& segmentId)
-{
-    if (currentVolume == nullptr || !_vol_qsurfs.count(segmentId)) {
-        QMessageBox::warning(this, tr("Error"), tr("Cannot render segment: No volume or invalid segment selected"));
-        return;
-    }
-    
-    QSettings settings("VC.ini", QSettings::IniFormat);
-    
-    QString defaultVolume = settings.value("rendering/default_volume", "").toString();
-    QString outputFormat = settings.value("rendering/output_path_format", "%s/layers/%02d.tif").toString();
-    float scale = settings.value("rendering/scale", 1.0f).toFloat();
-    int resolution = settings.value("rendering/resolution", 0).toInt();
-    int layers = settings.value("rendering/layers", 21).toInt();
-    
-    std::shared_ptr<volcart::Volume> volumeToRender;
-    if (defaultVolume.isEmpty()) {
-        volumeToRender = currentVolume;
-    } else {
-        try {
-            volumeToRender = fVpkg->volume(defaultVolume.toStdString());
-        } catch (const std::exception& e) {
-            QMessageBox::warning(this, tr("Error"), tr("Default volume not found. Using current volume instead."));
-            volumeToRender = currentVolume;
-        }
-    }
-    
-    QString volumePath = QString::fromStdString(volumeToRender->path().string());
-    QString segmentPath = QString::fromStdString(_vol_qsurfs[segmentId]->path.string());
-    QString segmentOutDir = QString::fromStdString(_vol_qsurfs[segmentId]->path.string());
-    QString outputPattern = outputFormat.replace("%s", segmentOutDir);
-    
-    // Initialize command line tool runner if needed
-    if (!_cmdRunner) {
-        _cmdRunner = new CommandLineToolRunner(statusBar, this);
-        connect(_cmdRunner, &CommandLineToolRunner::toolStarted, 
-                [this](CommandLineToolRunner::Tool tool, const QString& message) {
-                    statusBar->showMessage(message, 0);
-                });
-        connect(_cmdRunner, &CommandLineToolRunner::toolFinished, 
-                [this](CommandLineToolRunner::Tool tool, bool success, const QString& message, 
-                       const QString& outputPath, bool copyToClipboard) {
-                    if (success) {
-                        QString displayMsg = message;
-                        if (copyToClipboard) {
-                            displayMsg += tr(" - Path copied to clipboard");
-                        }
-                        statusBar->showMessage(displayMsg, 5000);
-                        QMessageBox::information(this, tr("Rendering Complete"), displayMsg);
-                    } else {
-                        statusBar->showMessage(tr("Rendering failed"), 5000);
-                        QMessageBox::critical(this, tr("Rendering Error"), message);
-                    }
-                });
-    }
-    
-    // Check if a tool is already running
-    if (_cmdRunner->isRunning()) {
-        QMessageBox::warning(this, tr("Warning"), tr("A command line tool is already running."));
-        return;
-    }
-    
-    // Set up parameters and execute the render tool
-    _cmdRunner->setVolumePath(volumePath);
-    _cmdRunner->setSegmentPath(segmentPath);
-    _cmdRunner->setOutputPattern(outputPattern);
-    _cmdRunner->setRenderParams(scale, resolution, layers);
-    
-    _cmdRunner->execute(CommandLineToolRunner::Tool::RenderTifXYZ);
-    
-    statusBar->showMessage(tr("Rendering segment: %1").arg(QString::fromStdString(segmentId)), 5000);
-}
-
-void CWindow::onGrowSegmentFromSegment(const SurfaceID& segmentId)
-{
-    if (currentVolume == nullptr || !_vol_qsurfs.count(segmentId)) {
-        QMessageBox::warning(this, tr("Error"), tr("Cannot grow segment: No volume or invalid segment selected"));
-        return;
-    }
-    
-    // Initialize command line tool runner if needed
-    if (!initializeCommandLineRunner()) {
-        return;
-    }
-    
-    // Check if a tool is already running
-    if (_cmdRunner->isRunning()) {
-        QMessageBox::warning(this, tr("Warning"), tr("A command line tool is already running."));
-        return;
-    }
-    
-    // Get paths
-    QString volumePath = getCurrentVolumePath();
-    if (volumePath.isEmpty()) {
-        QMessageBox::warning(this, tr("Error"), tr("Cannot grow segment: No volume selected"));
-        return;
-    }
-    QString srcSegment = QString::fromStdString(_vol_qsurfs[segmentId]->path.string());
-    
-    // Get the volpkg path and create traces directory if it doesn't exist
-    fs::path volpkgPath = fs::path(fVpkgPath.toStdString());
-    fs::path tracesDir = volpkgPath / "traces";
-    fs::path jsonParamsPath = volpkgPath / "trace_params.json";
-    fs::path pathsDir = volpkgPath / "paths";
-    
-    // Log information for debugging - write to console via statusBar
-    QString debugInfo = tr("Volume path: %1\n").arg(volumePath);
-    debugInfo += tr("Source segment: %1\n").arg(srcSegment);
-    debugInfo += tr("Source directory: %1\n").arg(QString::fromStdString(pathsDir.string()));
-    debugInfo += tr("Target directory: %1\n").arg(QString::fromStdString(tracesDir.string()));
-    debugInfo += tr("JSON parameters: %1").arg(QString::fromStdString(jsonParamsPath.string()));
-    statusBar->showMessage(tr("Preparing to run grow_seg_from_segment..."), 2000);
-    
-    // Create traces directory if it doesn't exist
-    if (!fs::exists(tracesDir)) {
-        try {
-            fs::create_directory(tracesDir);
-        } catch (const std::exception& e) {
-            QMessageBox::warning(this, tr("Error"), tr("Failed to create traces directory: %1").arg(e.what()));
-            return;
-        }
-    }
-    
-    // Check if trace_params.json exists
-    if (!fs::exists(jsonParamsPath)) {
-        QMessageBox::warning(this, tr("Error"), tr("trace_params.json not found in the volpkg"));
-        return;
-    }
-    
-    // Set up parameters and execute the tool
-    _cmdRunner->setTraceParams(
-        volumePath,
-        QString::fromStdString(pathsDir.string()),
-        QString::fromStdString(tracesDir.string()),
-        QString::fromStdString(jsonParamsPath.string()),
-        srcSegment
-    );
-    
-    // Show console before executing to see any debug output
-    _cmdRunner->showConsoleOutput();
-    
-    _cmdRunner->execute(CommandLineToolRunner::Tool::GrowSegFromSegment);
-    
-    statusBar->showMessage(tr("Growing segment from: %1").arg(QString::fromStdString(segmentId)), 5000);
-}
-
-void CWindow::onAddOverlap(const SurfaceID& segmentId)
-{
-    if (currentVolume == nullptr || !_vol_qsurfs.count(segmentId)) {
-        QMessageBox::warning(this, tr("Error"), tr("Cannot add overlap: No volume or invalid segment selected"));
-        return;
-    }
-    
-    // Initialize command line tool runner if needed
-    if (!initializeCommandLineRunner()) {
-        return;
-    }
-    
-    // Check if a tool is already running
-    if (_cmdRunner->isRunning()) {
-        QMessageBox::warning(this, tr("Warning"), tr("A command line tool is already running."));
-        return;
-    }
-    
-    // Get paths
-    fs::path volpkgPath = fs::path(fVpkgPath.toStdString());
-    fs::path pathsDir = volpkgPath / "paths";
-    QString tifxyzPath = QString::fromStdString(_vol_qsurfs[segmentId]->path.string());
-    
-    // Set up parameters and execute the tool
-    _cmdRunner->setAddOverlapParams(
-        QString::fromStdString(pathsDir.string()),
-        tifxyzPath
-    );
-    
-    _cmdRunner->execute(CommandLineToolRunner::Tool::SegAddOverlap);
-    
-    statusBar->showMessage(tr("Adding overlap for segment: %1").arg(QString::fromStdString(segmentId)), 5000);
-}
-
-void CWindow::onConvertToObj(const SurfaceID& segmentId)
-{
-    if (currentVolume == nullptr || !_vol_qsurfs.count(segmentId)) {
-        QMessageBox::warning(this, tr("Error"), tr("Cannot convert to OBJ: No volume or invalid segment selected"));
-        return;
-    }
-    
-    // Initialize command line tool runner if needed
-    if (!initializeCommandLineRunner()) {
-        return;
-    }
-    
-    // Check if a tool is already running
-    if (_cmdRunner->isRunning()) {
-        QMessageBox::warning(this, tr("Warning"), tr("A command line tool is already running."));
-        return;
-    }
-    
-    // Get source tifxyz path
-    fs::path tifxyzPath = _vol_qsurfs[segmentId]->path;
-    
-    // Generate output OBJ path (same directory with .obj extension)
-    fs::path objPath = tifxyzPath;
-    objPath.replace_extension(".obj");
-    
-    // Set up parameters and execute the tool
-    _cmdRunner->setToObjParams(
-        QString::fromStdString(tifxyzPath.string()),
-        QString::fromStdString(objPath.string())
-    );
-    
-    _cmdRunner->execute(CommandLineToolRunner::Tool::tifxyz2obj);
-    
-    statusBar->showMessage(tr("Converting segment to OBJ: %1").arg(QString::fromStdString(segmentId)), 5000);
-}
-
-void CWindow::onGrowSeeds(const SurfaceID& segmentId, bool isExpand, bool isRandomSeed)
-{
-    if (currentVolume == nullptr) {
-        QMessageBox::warning(this, tr("Error"), tr("Cannot grow seeds: No volume loaded"));
-        return;
-    }
-    
-    // Initialize command line tool runner if needed
-    if (!initializeCommandLineRunner()) {
-        return;
-    }
-    
-    // Check if a tool is already running
-    if (_cmdRunner->isRunning()) {
-        QMessageBox::warning(this, tr("Warning"), tr("A command line tool is already running."));
-        return;
-    }
-    
-    // Get paths
-    QString volumePath = getCurrentVolumePath();
-    if (volumePath.isEmpty()) {
-        QMessageBox::warning(this, tr("Error"), tr("Cannot grow seeds: No volume selected"));
-        return;
-    }
-    fs::path volpkgPath = fs::path(fVpkgPath.toStdString());
-    fs::path tracesDir = volpkgPath / "traces";
-    
-    // Create traces directory if it doesn't exist
-    if (!fs::exists(tracesDir)) {
-        try {
-            fs::create_directory(tracesDir);
-        } catch (const std::exception& e) {
-            QMessageBox::warning(this, tr("Error"), tr("Failed to create traces directory: %1").arg(e.what()));
-            return;
-        }
-    }
-    
-    // Get JSON parameters file
-    QString jsonFileName = isExpand ? "expand.json" : "seed.json";
-    fs::path jsonParamsPath = volpkgPath / jsonFileName.toStdString();
-    
-    // Check if JSON file exists
-    if (!fs::exists(jsonParamsPath)) {
-        QMessageBox::warning(this, tr("Error"), tr("%1 not found in the volpkg").arg(jsonFileName));
-        return;
-    }
-    
-    // Get current POI (focus point) for seed coordinates if needed
-    int seedX = 0, seedY = 0, seedZ = 0;
-    if (!isExpand && !isRandomSeed) {
-        POI *poi = _surf_col->poi("focus");
-        if (!poi) {
-            QMessageBox::warning(this, tr("Error"), tr("No focus point selected. Click on a volume with Ctrl key to set a seed point."));
-            return;
-        }
-        seedX = static_cast<int>(poi->p[0]);
-        seedY = static_cast<int>(poi->p[1]);
-        seedZ = static_cast<int>(poi->p[2]);
-    }
-    
-    // Set up parameters and execute the tool
-    _cmdRunner->setGrowParams(
-        volumePath,
-        QString::fromStdString(tracesDir.string()),
-        QString::fromStdString(jsonParamsPath.string()),
-        seedX,
-        seedY,
-        seedZ,
-        isExpand,
-        isRandomSeed
-    );
-    
-    _cmdRunner->execute(CommandLineToolRunner::Tool::GrowSegFromSeeds);
-    
-    QString modeDesc = isExpand ? "expand mode" : 
-                      (isRandomSeed ? "random seed mode" : "seed mode");
-    statusBar->showMessage(tr("Growing segment using %1 in %2").arg(jsonFileName).arg(modeDesc), 5000);
-}
-
-// Helper method to initialize command line runner
-bool CWindow::initializeCommandLineRunner()
-{
-    if (!_cmdRunner) {
-        _cmdRunner = new CommandLineToolRunner(statusBar, this);
-        
-        // Read parallel processes and iteration count settings from INI file
-        QSettings settings("VC.ini", QSettings::IniFormat);
-        int parallelProcesses = settings.value("perf/parallel_processes", 8).toInt();
-        int iterationCount = settings.value("perf/iteration_count", 1000).toInt();
-        
-        // Apply the settings
-        _cmdRunner->setParallelProcesses(parallelProcesses);
-        _cmdRunner->setIterationCount(iterationCount);
-        
-        connect(_cmdRunner, &CommandLineToolRunner::toolStarted, 
-                [this](CommandLineToolRunner::Tool tool, const QString& message) {
-                    statusBar->showMessage(message, 0);
-                });
-        connect(_cmdRunner, &CommandLineToolRunner::toolFinished, 
-                [this](CommandLineToolRunner::Tool tool, bool success, const QString& message, 
-                       const QString& outputPath, bool copyToClipboard) {
-                    if (success) {
-                        QString displayMsg = message;
-                        if (copyToClipboard) {
-                            displayMsg += tr(" - Path copied to clipboard");
-                        }
-                        statusBar->showMessage(displayMsg, 5000);
-                        QMessageBox::information(this, tr("Operation Complete"), displayMsg);
-                    } else {
-                        statusBar->showMessage(tr("Operation failed"), 5000);
-                        QMessageBox::critical(this, tr("Error"), message);
-                    }
-                });
-    }
-    return true;
-}

--- a/apps/VC3D/CWindowContextMenu.cpp
+++ b/apps/VC3D/CWindowContextMenu.cpp
@@ -1,0 +1,344 @@
+#include "CWindow.hpp"
+#include "CSurfaceCollection.hpp"
+
+#include <QSettings>
+
+#include "vc/core/types/VolumePkg.hpp"
+#include "vc/core/util/Surface.hpp"
+
+namespace vc = volcart;
+using namespace ChaoVis;
+namespace fs = std::filesystem;
+
+void CWindow::onRenderSegment(const SurfaceID& segmentId)
+{
+    if (currentVolume == nullptr || !_vol_qsurfs.count(segmentId)) {
+        QMessageBox::warning(this, tr("Error"), tr("Cannot render segment: No volume or invalid segment selected"));
+        return;
+    }
+    
+    QSettings settings("VC.ini", QSettings::IniFormat);
+    
+    QString defaultVolume = settings.value("rendering/default_volume", "").toString();
+    QString outputFormat = settings.value("rendering/output_path_format", "%s/layers/%02d.tif").toString();
+    float scale = settings.value("rendering/scale", 1.0f).toFloat();
+    int resolution = settings.value("rendering/resolution", 0).toInt();
+    int layers = settings.value("rendering/layers", 21).toInt();
+    
+    std::shared_ptr<volcart::Volume> volumeToRender;
+    if (defaultVolume.isEmpty()) {
+        volumeToRender = currentVolume;
+    } else {
+        try {
+            volumeToRender = fVpkg->volume(defaultVolume.toStdString());
+        } catch (const std::exception& e) {
+            QMessageBox::warning(this, tr("Error"), tr("Default volume not found. Using current volume instead."));
+            volumeToRender = currentVolume;
+        }
+    }
+    
+    QString volumePath = QString::fromStdString(volumeToRender->path().string());
+    QString segmentPath = QString::fromStdString(_vol_qsurfs[segmentId]->path.string());
+    QString segmentOutDir = QString::fromStdString(_vol_qsurfs[segmentId]->path.string());
+    QString outputPattern = outputFormat.replace("%s", segmentOutDir);
+    
+    // Initialize command line tool runner if needed
+    if (!_cmdRunner) {
+        _cmdRunner = new CommandLineToolRunner(statusBar, this);
+        connect(_cmdRunner, &CommandLineToolRunner::toolStarted, 
+                [this](CommandLineToolRunner::Tool tool, const QString& message) {
+                    statusBar->showMessage(message, 0);
+                });
+        connect(_cmdRunner, &CommandLineToolRunner::toolFinished, 
+                [this](CommandLineToolRunner::Tool tool, bool success, const QString& message, 
+                       const QString& outputPath, bool copyToClipboard) {
+                    if (success) {
+                        QString displayMsg = message;
+                        if (copyToClipboard) {
+                            displayMsg += tr(" - Path copied to clipboard");
+                        }
+                        statusBar->showMessage(displayMsg, 5000);
+                        QMessageBox::information(this, tr("Rendering Complete"), displayMsg);
+                    } else {
+                        statusBar->showMessage(tr("Rendering failed"), 5000);
+                        QMessageBox::critical(this, tr("Rendering Error"), message);
+                    }
+                });
+    }
+    
+    // Check if a tool is already running
+    if (_cmdRunner->isRunning()) {
+        QMessageBox::warning(this, tr("Warning"), tr("A command line tool is already running."));
+        return;
+    }
+    
+    // Set up parameters and execute the render tool
+    _cmdRunner->setVolumePath(volumePath);
+    _cmdRunner->setSegmentPath(segmentPath);
+    _cmdRunner->setOutputPattern(outputPattern);
+    _cmdRunner->setRenderParams(scale, resolution, layers);
+    
+    _cmdRunner->execute(CommandLineToolRunner::Tool::RenderTifXYZ);
+    
+    statusBar->showMessage(tr("Rendering segment: %1").arg(QString::fromStdString(segmentId)), 5000);
+}
+
+void CWindow::onGrowSegmentFromSegment(const SurfaceID& segmentId)
+{
+    if (currentVolume == nullptr || !_vol_qsurfs.count(segmentId)) {
+        QMessageBox::warning(this, tr("Error"), tr("Cannot grow segment: No volume or invalid segment selected"));
+        return;
+    }
+    
+    // Initialize command line tool runner if needed
+    if (!initializeCommandLineRunner()) {
+        return;
+    }
+    
+    // Check if a tool is already running
+    if (_cmdRunner->isRunning()) {
+        QMessageBox::warning(this, tr("Warning"), tr("A command line tool is already running."));
+        return;
+    }
+    
+    // Get paths
+    QString volumePath = getCurrentVolumePath();
+    if (volumePath.isEmpty()) {
+        QMessageBox::warning(this, tr("Error"), tr("Cannot grow segment: No volume selected"));
+        return;
+    }
+    QString srcSegment = QString::fromStdString(_vol_qsurfs[segmentId]->path.string());
+    
+    // Get the volpkg path and create traces directory if it doesn't exist
+    fs::path volpkgPath = fs::path(fVpkgPath.toStdString());
+    fs::path tracesDir = volpkgPath / "traces";
+    fs::path jsonParamsPath = volpkgPath / "trace_params.json";
+    fs::path pathsDir = volpkgPath / "paths";
+    
+    // Log information for debugging - write to console via statusBar
+    QString debugInfo = tr("Volume path: %1\n").arg(volumePath);
+    debugInfo += tr("Source segment: %1\n").arg(srcSegment);
+    debugInfo += tr("Source directory: %1\n").arg(QString::fromStdString(pathsDir.string()));
+    debugInfo += tr("Target directory: %1\n").arg(QString::fromStdString(tracesDir.string()));
+    debugInfo += tr("JSON parameters: %1").arg(QString::fromStdString(jsonParamsPath.string()));
+    statusBar->showMessage(tr("Preparing to run grow_seg_from_segment..."), 2000);
+    
+    // Create traces directory if it doesn't exist
+    if (!fs::exists(tracesDir)) {
+        try {
+            fs::create_directory(tracesDir);
+        } catch (const std::exception& e) {
+            QMessageBox::warning(this, tr("Error"), tr("Failed to create traces directory: %1").arg(e.what()));
+            return;
+        }
+    }
+    
+    // Check if trace_params.json exists
+    if (!fs::exists(jsonParamsPath)) {
+        QMessageBox::warning(this, tr("Error"), tr("trace_params.json not found in the volpkg"));
+        return;
+    }
+    
+    // Set up parameters and execute the tool
+    _cmdRunner->setTraceParams(
+        volumePath,
+        QString::fromStdString(pathsDir.string()),
+        QString::fromStdString(tracesDir.string()),
+        QString::fromStdString(jsonParamsPath.string()),
+        srcSegment
+    );
+    
+    // Show console before executing to see any debug output
+    _cmdRunner->showConsoleOutput();
+    
+    _cmdRunner->execute(CommandLineToolRunner::Tool::GrowSegFromSegment);
+    
+    statusBar->showMessage(tr("Growing segment from: %1").arg(QString::fromStdString(segmentId)), 5000);
+}
+
+void CWindow::onAddOverlap(const SurfaceID& segmentId)
+{
+    if (currentVolume == nullptr || !_vol_qsurfs.count(segmentId)) {
+        QMessageBox::warning(this, tr("Error"), tr("Cannot add overlap: No volume or invalid segment selected"));
+        return;
+    }
+    
+    // Initialize command line tool runner if needed
+    if (!initializeCommandLineRunner()) {
+        return;
+    }
+    
+    // Check if a tool is already running
+    if (_cmdRunner->isRunning()) {
+        QMessageBox::warning(this, tr("Warning"), tr("A command line tool is already running."));
+        return;
+    }
+    
+    // Get paths
+    fs::path volpkgPath = fs::path(fVpkgPath.toStdString());
+    fs::path pathsDir = volpkgPath / "paths";
+    QString tifxyzPath = QString::fromStdString(_vol_qsurfs[segmentId]->path.string());
+    
+    // Set up parameters and execute the tool
+    _cmdRunner->setAddOverlapParams(
+        QString::fromStdString(pathsDir.string()),
+        tifxyzPath
+    );
+    
+    _cmdRunner->execute(CommandLineToolRunner::Tool::SegAddOverlap);
+    
+    statusBar->showMessage(tr("Adding overlap for segment: %1").arg(QString::fromStdString(segmentId)), 5000);
+}
+
+void CWindow::onConvertToObj(const SurfaceID& segmentId)
+{
+    if (currentVolume == nullptr || !_vol_qsurfs.count(segmentId)) {
+        QMessageBox::warning(this, tr("Error"), tr("Cannot convert to OBJ: No volume or invalid segment selected"));
+        return;
+    }
+    
+    // Initialize command line tool runner if needed
+    if (!initializeCommandLineRunner()) {
+        return;
+    }
+    
+    // Check if a tool is already running
+    if (_cmdRunner->isRunning()) {
+        QMessageBox::warning(this, tr("Warning"), tr("A command line tool is already running."));
+        return;
+    }
+    
+    // Get source tifxyz path
+    fs::path tifxyzPath = _vol_qsurfs[segmentId]->path;
+    
+    // Generate output OBJ path (same directory with .obj extension)
+    fs::path objPath = tifxyzPath;
+    objPath.replace_extension(".obj");
+    
+    // Set up parameters and execute the tool
+    _cmdRunner->setToObjParams(
+        QString::fromStdString(tifxyzPath.string()),
+        QString::fromStdString(objPath.string())
+    );
+    
+    _cmdRunner->execute(CommandLineToolRunner::Tool::tifxyz2obj);
+    
+    statusBar->showMessage(tr("Converting segment to OBJ: %1").arg(QString::fromStdString(segmentId)), 5000);
+}
+
+void CWindow::onGrowSeeds(const SurfaceID& segmentId, bool isExpand, bool isRandomSeed)
+{
+    if (currentVolume == nullptr) {
+        QMessageBox::warning(this, tr("Error"), tr("Cannot grow seeds: No volume loaded"));
+        return;
+    }
+    
+    // Initialize command line tool runner if needed
+    if (!initializeCommandLineRunner()) {
+        return;
+    }
+    
+    // Check if a tool is already running
+    if (_cmdRunner->isRunning()) {
+        QMessageBox::warning(this, tr("Warning"), tr("A command line tool is already running."));
+        return;
+    }
+    
+    // Get paths
+    QString volumePath = getCurrentVolumePath();
+    if (volumePath.isEmpty()) {
+        QMessageBox::warning(this, tr("Error"), tr("Cannot grow seeds: No volume selected"));
+        return;
+    }
+    fs::path volpkgPath = fs::path(fVpkgPath.toStdString());
+    fs::path tracesDir = volpkgPath / "traces";
+    
+    // Create traces directory if it doesn't exist
+    if (!fs::exists(tracesDir)) {
+        try {
+            fs::create_directory(tracesDir);
+        } catch (const std::exception& e) {
+            QMessageBox::warning(this, tr("Error"), tr("Failed to create traces directory: %1").arg(e.what()));
+            return;
+        }
+    }
+    
+    // Get JSON parameters file
+    QString jsonFileName = isExpand ? "expand.json" : "seed.json";
+    fs::path jsonParamsPath = volpkgPath / jsonFileName.toStdString();
+    
+    // Check if JSON file exists
+    if (!fs::exists(jsonParamsPath)) {
+        QMessageBox::warning(this, tr("Error"), tr("%1 not found in the volpkg").arg(jsonFileName));
+        return;
+    }
+    
+    // Get current POI (focus point) for seed coordinates if needed
+    int seedX = 0, seedY = 0, seedZ = 0;
+    if (!isExpand && !isRandomSeed) {
+        POI *poi = _surf_col->poi("focus");
+        if (!poi) {
+            QMessageBox::warning(this, tr("Error"), tr("No focus point selected. Click on a volume with Ctrl key to set a seed point."));
+            return;
+        }
+        seedX = static_cast<int>(poi->p[0]);
+        seedY = static_cast<int>(poi->p[1]);
+        seedZ = static_cast<int>(poi->p[2]);
+    }
+    
+    // Set up parameters and execute the tool
+    _cmdRunner->setGrowParams(
+        volumePath,
+        QString::fromStdString(tracesDir.string()),
+        QString::fromStdString(jsonParamsPath.string()),
+        seedX,
+        seedY,
+        seedZ,
+        isExpand,
+        isRandomSeed
+    );
+    
+    _cmdRunner->execute(CommandLineToolRunner::Tool::GrowSegFromSeeds);
+    
+    QString modeDesc = isExpand ? "expand mode" : 
+                      (isRandomSeed ? "random seed mode" : "seed mode");
+    statusBar->showMessage(tr("Growing segment using %1 in %2").arg(jsonFileName).arg(modeDesc), 5000);
+}
+
+// Helper method to initialize command line runner
+bool CWindow::initializeCommandLineRunner()
+{
+    if (!_cmdRunner) {
+        _cmdRunner = new CommandLineToolRunner(statusBar, this);
+        
+        // Read parallel processes and iteration count settings from INI file
+        QSettings settings("VC.ini", QSettings::IniFormat);
+        int parallelProcesses = settings.value("perf/parallel_processes", 8).toInt();
+        int iterationCount = settings.value("perf/iteration_count", 1000).toInt();
+        
+        // Apply the settings
+        _cmdRunner->setParallelProcesses(parallelProcesses);
+        _cmdRunner->setIterationCount(iterationCount);
+        
+        connect(_cmdRunner, &CommandLineToolRunner::toolStarted, 
+                [this](CommandLineToolRunner::Tool tool, const QString& message) {
+                    statusBar->showMessage(message, 0);
+                });
+        connect(_cmdRunner, &CommandLineToolRunner::toolFinished, 
+                [this](CommandLineToolRunner::Tool tool, bool success, const QString& message, 
+                       const QString& outputPath, bool copyToClipboard) {
+                    if (success) {
+                        QString displayMsg = message;
+                        if (copyToClipboard) {
+                            displayMsg += tr(" - Path copied to clipboard");
+                        }
+                        statusBar->showMessage(displayMsg, 5000);
+                        QMessageBox::information(this, tr("Operation Complete"), displayMsg);
+                    } else {
+                        statusBar->showMessage(tr("Operation failed"), 5000);
+                        QMessageBox::critical(this, tr("Error"), message);
+                    }
+                });
+    }
+    return true;
+}

--- a/apps/VC3D/SurfaceTreeWidget.cpp
+++ b/apps/VC3D/SurfaceTreeWidget.cpp
@@ -3,12 +3,12 @@
 #include <QObject>
 #include <QApplication>
 
-QTreeWidgetItem* SurfaceTreeWidget::findItemForSurface(SurfaceID id)
+SurfaceTreeWidgetItem* SurfaceTreeWidget::findItemForSurface(SurfaceID id)
 {
     QTreeWidgetItemIterator it(this);
     while (*it) {
         if (id == (*it)->data(SURFACE_ID_COLUMN, Qt::UserRole).toString().toStdString()) {
-            return (*it);
+            return static_cast<SurfaceTreeWidgetItem*>(*it);
         }
 
         ++it;

--- a/apps/VC3D/SurfaceTreeWidget.hpp
+++ b/apps/VC3D/SurfaceTreeWidget.hpp
@@ -6,16 +6,6 @@
 
 #define SURFACE_ID_COLUMN 1
 
-class SurfaceTreeWidget : public QTreeWidget
-{
-public:
-    SurfaceTreeWidget(QTreeWidget* parent) : QTreeWidget(parent) {
-        setContextMenuPolicy(Qt::CustomContextMenu);
-    }
-    
-    QTreeWidgetItem* findItemForSurface(SurfaceID id);
-};
-
 class SurfaceTreeWidgetItem : public QTreeWidgetItem
 {
 public:
@@ -35,4 +25,16 @@ private:
         else
             return text(column).toDouble() < other.text(column).toDouble();
     }
+};
+
+class SurfaceTreeWidget : public QTreeWidget
+{
+    Q_OBJECT
+
+public:
+    SurfaceTreeWidget(QWidget* parent = nullptr) : QTreeWidget(parent) {
+        setContextMenuPolicy(Qt::CustomContextMenu);
+    }
+    
+    SurfaceTreeWidgetItem* findItemForSurface(SurfaceID id);
 };

--- a/apps/VC3D/VCAppMain.cpp
+++ b/apps/VC3D/VCAppMain.cpp
@@ -20,9 +20,9 @@ auto main(int argc, char* argv[]) -> int
     
     QApplication app(argc, argv);
     QApplication::setOrganizationName("EduceLab");
-    QApplication::setApplicationName("VC");
-    QApplication::setApplicationVersion(
-        QString::fromStdString(vc::ProjectInfo::VersionString()));
+    QApplication::setApplicationName("VC3D");
+    QApplication::setWindowIcon(QIcon(":/images/logo.png"));
+    QApplication::setApplicationVersion(QString::fromStdString(vc::ProjectInfo::VersionString()));
 
     CWindow aWin;
     aWin.show();

--- a/apps/VC3D/VCMain.ui
+++ b/apps/VC3D/VCMain.ui
@@ -17,7 +17,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>Volume Cartographer</string>
+   <string>Volume Cartographer 3D</string>
   </property>
   <property name="dockOptions">
    <set>QMainWindow::DockOption::AllowNestedDocks|QMainWindow::DockOption::AllowTabbedDocks|QMainWindow::DockOption::AnimatedDocks</set>
@@ -188,7 +188,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QTreeWidget" name="treeWidgetSurfaces">
+           <widget class="SurfaceTreeWidget" name="treeWidgetSurfaces">
             <property name="alternatingRowColors">
              <bool>true</bool>
             </property>
@@ -901,6 +901,13 @@
   </action>
   <zorder>dockWidgetOpList</zorder>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>SurfaceTreeWidget</class>
+   <extends>QTreeWidget</extends>
+   <header>../../../../../apps/VC3D/SurfaceTreeWidget.hpp</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
  <buttongroups>

--- a/apps/VC3D/vc3d.desktop
+++ b/apps/VC3D/vc3d.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=1.0
+Name=Volume Cartographer 3D
+Comment=Volumetric processing toolkit
+GenericName=Volumetric Editor
+Exec=/bin/VC3D
+Icon=vc3d.svg
+Type=Application
+StartupWMClass=VC3D

--- a/cmake/VCFindDependencies.cmake
+++ b/cmake/VCFindDependencies.cmake
@@ -24,15 +24,15 @@ list(APPEND VC_CUSTOM_MODULES "${CMAKE_MODULE_PATH}/FindFilesystem.cmake")
 if((VC_BUILD_APPS OR VC_BUILD_UTILS) AND VC_BUILD_GUI)
     find_package(Qt6 QUIET REQUIRED COMPONENTS Widgets Gui Core Network)
     # qt_standard_project_setup() #NOTE below settings for QT < 6.3, commented command for qt >= 6.3, ubuntu 22.04 has qt 6.2!
-     set(CMAKE_AUTOMOC ON)
-     set(CMAKE_AUTORCC ON)
-     set(CMAKE_AUTOUIC ON)
+    set(CMAKE_AUTOMOC ON)
+    set(CMAKE_AUTORCC ON)
+    set(CMAKE_AUTOUIC ON)
      
-     if(NOT DEFINED qt_generate_deploy_app_script)
-            message(WARNING "WARNING qt_generate_deploy_app_script MISSING!")
+    if(NOT DEFINED qt_generate_deploy_app_script)
+        message(WARNING "WARNING qt_generate_deploy_app_script MISSING!")
         function(qt_generate_deploy_app_script)
         endfunction()
-     endif()
+    endif()
      
 endif()
 
@@ -41,7 +41,7 @@ if (VC_WITH_CUDA_SPARSE)
     add_definitions(-DVC_USE_CUDA_SPARSE=1)
 endif()
 
-#ceres-solver
+### ceres-solver ###
 find_package(Ceres REQUIRED)
 
 ### Z5 ###
@@ -75,7 +75,7 @@ include(BuildJSON)
 ### CURL library (needed for GDAL) ###
 find_package(CURL REQUIRED)
 
-### Boost and indicators (for app use only)
+### Boost and indicators (for app use only) ###
 if(VC_BUILD_APPS OR VC_BUILD_UTILS)
     find_package(Boost 1.58 REQUIRED COMPONENTS system program_options)
     include(BuildIndicators)

--- a/ubuntu-22.04-jammy.Dockerfile
+++ b/ubuntu-22.04-jammy.Dockerfile
@@ -2,33 +2,34 @@ FROM ubuntu:jammy
 
 RUN apt-get update
 RUN apt-get -y upgrade
-RUN apt -y install build-essential git cmake
 RUN apt-get -y install software-properties-common
 RUN add-apt-repository universe
-RUN apt-get -y install qt6-base-dev
-RUN apt-get -y install libgl1-mesa-dev libglvnd-dev
+RUN apt-get update
+RUN apt-get -y install build-essential git cmake 
+RUN apt-get -y install qt6-base-dev libgl1-mesa-dev libglvnd-dev
 
 ENV TZ=Europe/Berlin
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt install -y tzdata
 
 RUN apt-get -y install libceres-dev libboost-system-dev libboost-program-options-dev xtensor-dev libopencv-dev
-RUN apt-get -y install libblosc-dev libspdlog-dev libsdl2-dev
-RUN apt-get -y install libgsl-dev
+RUN apt-get -y install libblosc-dev libspdlog-dev 
+RUN apt-get -y install libgsl-dev libsdl2-dev libcurl4-openssl-dev
 RUN apt-get -y install file
 
 COPY . /src
+RUN rm /src/CMakeCache.txt || true
 
-RUN mkdir /build
-WORKDIR /build
+RUN ls /src
+RUN mkdir /src/build
+WORKDIR /src/build
 
-RUN cmake -DVC_BUILD_JSON=on -DVC_WITH_CUDA_SPARSE=off /src
+RUN cmake -DVC_WITH_CUDA_SPARSE=off /src
 RUN make -j$(nproc --all)
-#RUN make install
 
 RUN cpack -G DEB -V
 
-RUN dpkg -i /build/pkgs/vc3d*.deb
+RUN dpkg -i /src/build/pkgs/vc3d*.deb
 
 RUN apt-get -y autoremove
 RUN rm -r /src

--- a/ubuntu-24.10-oracular.Dockerfile
+++ b/ubuntu-24.10-oracular.Dockerfile
@@ -6,25 +6,24 @@ RUN apt-get -y install software-properties-common
 RUN add-apt-repository universe
 RUN apt-get update
 RUN apt-get -y install build-essential git cmake 
-RUN apt-get -y install qt6-base-dev libboost-system-dev libboost-program-options-dev 
-RUN apt-get -y install libceres-dev xtensor-dev libopencv-dev libxsimd-dev libblosc-dev libspdlog-dev 
+RUN apt-get -y install qt6-base-dev libboost-system-dev libboost-program-options-dev
+RUN apt-get -y install libceres-dev xtensor-dev libopencv-dev libxsimd-dev libblosc-dev libspdlog-dev
 RUN apt-get -y install libgsl-dev libsdl2-dev libcurl4-openssl-dev
-
 RUN apt-get -y install file
 
 COPY . /src
 RUN rm /src/CMakeCache.txt || true
 
 RUN ls /src
-RUN mkdir /build
-WORKDIR /build
+RUN mkdir /src/build
+WORKDIR /src/build
 
 RUN cmake -DVC_WITH_CUDA_SPARSE=off /src
 RUN make -j$(nproc --all)
 
 RUN cpack -G DEB -V
 
-RUN dpkg -i /build/pkgs/vc3d*.deb
+RUN dpkg -i /src/build/pkgs/vc3d*.deb
 
 RUN apt-get -y autoremove
 RUN rm -r /src

--- a/ubuntu-25.04-plucky.Dockerfile
+++ b/ubuntu-25.04-plucky.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:noble
+FROM ubuntu:plucky
 
 RUN apt-get update
 RUN apt-get -y upgrade
@@ -7,7 +7,6 @@ RUN add-apt-repository universe
 RUN apt-get update
 RUN apt-get -y install build-essential git cmake 
 RUN apt-get -y install qt6-base-dev libboost-system-dev libboost-program-options-dev
-RUN apt-get update
 RUN apt-get -y install libceres-dev xtensor-dev libopencv-dev libxsimd-dev libblosc-dev libspdlog-dev
 RUN apt-get -y install libgsl-dev libsdl2-dev libcurl4-openssl-dev
 RUN apt-get -y install file


### PR DESCRIPTION
I upgrade to Ubuntu 25.04 which means Qt 6.8 and then also ran into the QT_OBJECT issue for the surface tree w2idget that @bruniss faced a couple of weeks ago. I was now able to resolve it by promoting the widget in QtDesigner. I however had to fight quite a while with the relative paths for the builds to properly work again.

I also added a 25.04 Dockerfile plus `vc3d.desktop` file. For the latter:

1. The `Exec` path needs to be adjusted to wherever locally you have VC3D built/installed.
2. The file then copied into `/usr/share/applications`.
3. Copy the `logo.svg` from `/docs/images` into `/usr/share/icons/hicolor/scalable/apps`
4. After that, the Ubuntu launcher will properly show the logo for VC3D plus the app can be pinned to the launcher for easy access.

![image](https://github.com/user-attachments/assets/f977ce8d-2f29-4484-b199-24cee24ea375)

**Note**: The path in the Dockerfiles needed to be changed for the relative widget promotion paths to be valid and work during compilation.
