### PR TITLE
Fix crashes and regressions from recent multi-selection and seg-dir-switcher merges

### DIFF
--- a/apps/VC3D/CWindow.hpp
+++ b/apps/VC3D/CWindow.hpp
@@ -124,7 +124,7 @@ private slots:
     void About(void);
     void ShowSettings();
     void ResetSegmentationViews();
-    void onSurfaceSelected(QTreeWidgetItem *current, QTreeWidgetItem *previous);
+    void onSurfaceSelected();
     void onSegFilterChanged(int index);
     void onSegmentationDirChanged(int index);
     void onEditMaskPressed();

--- a/apps/VC3D/OpsList.cpp
+++ b/apps/VC3D/OpsList.cpp
@@ -11,10 +11,10 @@ OpsList::OpsList(QWidget* parent) : QWidget(parent), ui(new Ui::OpsList)
 {
     ui->setupUi(this);
 
-    _tree = this->findChild<QTreeWidget*>("treeWidget");
-    _add_sel = this->findChild<QComboBox*>("comboOp");
+    _tree = ui->treeWidget;
+    _add_sel = ui->comboOp;
     connect(_tree, &QTreeWidget::currentItemChanged, this, &OpsList::onSelChanged);
-    connect(this->findChild<QPushButton*>("pushAppendOp"), &QPushButton::clicked, this, &OpsList::onAppendOpClicked);
+    connect(ui->pushAppendOp, &QPushButton::clicked, this, &OpsList::onAppendOpClicked);
 }
 
 OpsList::~OpsList() { delete ui; }
@@ -22,18 +22,20 @@ OpsList::~OpsList() { delete ui; }
 void OpsList::onOpChainSelected(OpChain *ops)
 {
     _op_chain = ops;
-    std::cout << "opchain selected " << ops << std::endl;
+    std::cout << "OpChain/Layer selected " << ops << std::endl;
 
     _tree->clear();
 
-    QTreeWidgetItem *item = new QTreeWidgetItem(_tree);
-    item->setText(0, QString(op_name(_op_chain)));
-    item->setData(0, Qt::UserRole, QVariant::fromValue((void*)_op_chain));
-
-    for (auto& op : _op_chain->ops()) {
+    if (_op_chain) {
         QTreeWidgetItem *item = new QTreeWidgetItem(_tree);
-        item->setText(0, QString(op_name(op)));
-        item->setData(0, Qt::UserRole, QVariant::fromValue((void*)op));
+        item->setText(0, QString(op_name(_op_chain)));
+        item->setData(0, Qt::UserRole, QVariant::fromValue((void*)_op_chain));
+
+        for (auto& op : _op_chain->ops()) {
+            QTreeWidgetItem *item = new QTreeWidgetItem(_tree);
+            item->setText(0, QString(op_name(op)));
+            item->setData(0, Qt::UserRole, QVariant::fromValue((void*)op));
+        }
     }
 }
 


### PR DESCRIPTION
- For the multi selection to work and still react correctly to the first click we need the callback `itemSelectionChanged`
- Clear layer/opchain selection when changing segmentation dirs (otherwise clicks in the layer list or the "Append" button crashes the app
- Adjust surface reload feature, to consider the segmentation dirs to not incorrectly reset the shown list
- Reset "segmentation" sub window title
- Prevent Qt 6.8 compile warning due to changed signal
