### PR TITLE
Report areas in cm2, and save areas with tracer segments

### DIFF
--- a/apps/src/vc_grow_seg_from_seed.cpp
+++ b/apps/src/vc_grow_seg_from_seed.cpp
@@ -313,13 +313,12 @@ int main(int argc, char *argv[])
     if (thread_limit)
         omp_set_num_threads(thread_limit);
 
-    QuadSurface *surf = space_tracing_quad_phys(ds.get(), 1.0, &chunk_cache, origin, generations, step_size, cache_root);
+    QuadSurface *surf = space_tracing_quad_phys(ds.get(), 1.0, &chunk_cache, origin, generations, step_size, cache_root, voxelsize);
 
-    double area_cm2 = (*surf->meta)["area_vx2"].get<double>()*voxelsize*voxelsize/1e8;
+    double area_cm2 = (*surf->meta)["area_cm2"].get<double>();
     if (area_cm2 < min_area_cm)
         return EXIT_SUCCESS;
 
-    (*surf->meta)["area_cm2"] = area_cm2;
     (*surf->meta)["source"] = "vc_grow_seg_from_seed";
     (*surf->meta)["vc_gsfs_params"] = params;
     (*surf->meta)["vc_gsfs_mode"] = mode;

--- a/apps/src/vc_grow_seg_from_segments.cpp
+++ b/apps/src/vc_grow_seg_from_segments.cpp
@@ -118,6 +118,8 @@ int main(int argc, char *argv[])
     std::cout << "zarr dataset size for scale group 0 " << ds->shape() << std::endl;
     std::cout << "chunk shape shape " << ds->chunking().blockShape() << std::endl;
 
+    float voxelsize = json::parse(std::ifstream(vol_path/"meta.json"))["voxelsize"];
+
     std::string name_prefix = "auto_grown_";
     std::vector<SurfaceMeta*> surfaces;
 
@@ -168,7 +170,7 @@ int main(int argc, char *argv[])
             surfaces.push_back(sm);
         }
 
-    QuadSurface *surf = grow_surf_from_surfs(src, surfaces, params);
+    QuadSurface *surf = grow_surf_from_surfs(src, surfaces, params, voxelsize);
 
     if (!surf)
         return EXIT_SUCCESS;

--- a/core/include/vc/core/util/Surface.hpp
+++ b/core/include/vc/core/util/Surface.hpp
@@ -41,7 +41,7 @@ Rect3D expand_rect(const Rect3D &a, const cv::Vec3f &p);
 QuadSurface *load_quad_from_vcps(const std::string &path);
 QuadSurface *load_quad_from_obj(const std::string &path);
 QuadSurface *load_quad_from_tifxyz(const std::string &path);
-QuadSurface *space_tracing_quad_phys(z5::Dataset *ds, float scale, ChunkCache *cache, cv::Vec3f origin, int generations = 100, float step = 10, const std::string &cache_root = "");
+QuadSurface *space_tracing_quad_phys(z5::Dataset *ds, float scale, ChunkCache *cache, cv::Vec3f origin, int generations = 100, float step = 10, const std::string &cache_root = "", float voxelsize = 1.0);
 QuadSurface *regularized_local_quad(QuadSurface *src, SurfacePointer *ptr, int w, int h, int step_search = 100, int step_out = 5);
 QuadSurface *smooth_vc_segmentation(QuadSurface *src);
 

--- a/core/include/vc/core/util/Surface.hpp
+++ b/core/include/vc/core/util/Surface.hpp
@@ -239,6 +239,6 @@ void find_intersect_segments(std::vector<std::vector<cv::Vec3f>> &seg_vol, std::
 
 float min_loc(const cv::Mat_<cv::Vec3f> &points, cv::Vec2f &loc, cv::Vec3f &out, const std::vector<cv::Vec3f> &tgts, const std::vector<float> &tds, PlaneSurface *plane, float init_step = 16.0, float min_step = 0.125);
 
-QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMeta*> &surfs_v, const nlohmann::json &params);
+QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMeta*> &surfs_v, const nlohmann::json &params, float voxelsize = 1.0);
 float pointTo(cv::Vec2f &loc, const cv::Mat_<cv::Vec3d> &points, const cv::Vec3f &tgt, float th, int max_iters, float scale);
 float pointTo(cv::Vec2f &loc, const cv::Mat_<cv::Vec3f> &points, const cv::Vec3f &tgt, float th, int max_iters, float scale);

--- a/core/src/SurfaceHelpers.cpp
+++ b/core/src/SurfaceHelpers.cpp
@@ -3185,6 +3185,8 @@ QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMe
     QuadSurface *surf = new QuadSurface(points_hr(used_area_hr), {1/src_step,1/src_step});
 
     surf->meta = new nlohmann::json;
+    (*surf->meta)["area_vx2"] = area_est_vx2;
+    (*surf->meta)["area_cm2"] = area_est_cm2;
 
     return surf;
 }

--- a/core/src/SurfaceHelpers.cpp
+++ b/core/src/SurfaceHelpers.cpp
@@ -2559,7 +2559,7 @@ void optimize_surface_mapping(SurfTrackerData &data, cv::Mat_<uint8_t> &state, c
     dbg_counter++;
 }
 
-QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMeta*> &surfs_v, const nlohmann::json &params)
+QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMeta*> &surfs_v, const nlohmann::json &params, float voxelsize)
 {
     bool flip_x = params.value("flip_x", 0);
     int global_steps_per_window = params.value("global_steps_per_window", 0);
@@ -3123,9 +3123,11 @@ QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMe
             }
         }
 
-        printf("gen %d processing %lu fringe cands (total done %d fringe: %lu) area %f vx^2 best th: %d\n", 
+        float const current_area_vx2 = loc_valid_count*src_step*src_step*step*step;
+        float const current_area_cm2 = current_area_vx2 * voxelsize * voxelsize / 1e8;
+        printf("gen %d processing %lu fringe cands (total done %d fringe: %lu) area %.0f vx^2 (%f cm^2) best th: %d\n", 
                generation, static_cast<unsigned long>(cands.size()), succ, static_cast<unsigned long>(fringe.size()), 
-               loc_valid_count*src_step*src_step*step*step, best_inliers_gen);
+               current_area_vx2, current_area_cm2, best_inliers_gen);
         
         //continue expansion
         if (!fringe.size() && w < max_width/step)
@@ -3174,7 +3176,9 @@ QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMe
             break;
     }
     
-    std::cout << "area est: " << loc_valid_count*src_step*src_step*step*step << "vx^2" << std::endl;
+    float const area_est_vx2 = loc_valid_count*src_step*src_step*step*step;
+    float const area_est_cm2 = area_est_vx2 * voxelsize * voxelsize / 1e8;
+    std::cout << "area est: " << area_est_vx2 << " vx^2 (" << area_est_cm2 << " cm^2)" << std::endl;
 
     cv::Mat_<cv::Vec3d> points_hr = surftrack_genpoints_hr(data, state, points, used_area, step, src_step);
 


### PR DESCRIPTION
- passes through `voxelsize` to `space_tracing_quad_phys` and `grow_surf_from_surfs`
- these now report areas in cm^2
- `grow_surf_from_surfs` also writes areas to metadata