### PR TITLE
read write an overlapping.json rather than outputting a list of files to a directory

### DIFF
--- a/apps/VC3D/CVolumeViewer.cpp
+++ b/apps/VC3D/CVolumeViewer.cpp
@@ -895,8 +895,7 @@ void CVolumeViewer::renderIntersections()
             
             std::unordered_map<cv::Vec3f,cv::Vec3f,vec3f_hash> location_cache;
             std::vector<cv::Vec3f> src_locations;
-            SurfacePointer *ptrs[omp_get_max_threads()] = {};
-            
+
             for (auto seg : _surf_col->intersection(pair.first, pair.second)->lines)
                 for (auto wp : seg)
                     src_locations.push_back(wp);

--- a/apps/src/vc_seg_add_overlap.cpp
+++ b/apps/src/vc_seg_add_overlap.cpp
@@ -1,11 +1,9 @@
 #include "vc/core/util/Slicing.hpp"
 #include "vc/core/util/Surface.hpp"
 #include <nlohmann/json.hpp>
-
 #include <fstream>
 
 namespace fs = std::filesystem;
-
 using json = nlohmann::json;
 
 std::ostream& operator<< (std::ostream& out, const xt::svector<size_t> &v) {
@@ -25,23 +23,23 @@ int main(int argc, char *argv[])
         std::cout << "   this will check for overlap between any tiffxyz in target dir and <single-tiffxyz> and add overlap metadata" << std::endl;
         return EXIT_SUCCESS;
     }
+
     fs::path tgt_dir = argv[1];
     fs::path seg_dir = argv[2];
-
     int search_iters = 10;
-
     srand(clock());
 
     SurfaceMeta current(seg_dir);
 
-    fs::path overlap_dir = current.path / "overlapping";
-    fs::create_directory(overlap_dir);
+    // Read existing overlapping data for current segment
+    std::set<std::string> current_overlapping = read_overlapping_json(current.path);
+
+    bool found_overlaps = false;
 
     for (const auto& entry : fs::directory_iterator(tgt_dir))
         if (fs::is_directory(entry))
         {
             std::string name = entry.path().filename();
-
             if (name == current.name())
                 continue;
 
@@ -50,7 +48,13 @@ int main(int argc, char *argv[])
                 continue;
 
             std::ifstream meta_f(meta_fn);
-            json meta = json::parse(meta_f);
+            json meta;
+            try {
+                meta = json::parse(meta_f);
+            } catch (const json::exception& e) {
+                std::cerr << "Error parsing meta.json for " << name << ": " << e.what() << std::endl;
+                continue;
+            }
 
             if (!meta.count("bbox"))
                 continue;
@@ -62,12 +66,26 @@ int main(int argc, char *argv[])
             other.readOverlapping();
 
             if (overlap(current, other, search_iters)) {
-                std::ofstream touch_me(overlap_dir/other.name());
-                fs::path overlap_other = other.path / "overlapping";
-                fs::create_directory(overlap_other);
-                std::ofstream touch_you(overlap_other/current.name());
+                found_overlaps = true;
+
+                // Add to current's overlapping set
+                current_overlapping.insert(other.name());
+
+                // Read and update other's overlapping set
+                std::set<std::string> other_overlapping = read_overlapping_json(other.path);
+                other_overlapping.insert(current.name());
+                write_overlapping_json(other.path, other_overlapping);
+
+                std::cout << "Found overlap: " << current.name() << " <-> " << other.name() << std::endl;
             }
         }
-    
+
+    // Write current's overlapping data
+    if (found_overlaps || !current_overlapping.empty()) {
+        write_overlapping_json(current.path, current_overlapping);
+        std::cout << "Updated overlapping data for " << current.name()
+                  << " (" << current_overlapping.size() << " overlaps)" << std::endl;
+    }
+
     return EXIT_SUCCESS;
 }

--- a/core/include/vc/core/util/Surface.hpp
+++ b/core/include/vc/core/util/Surface.hpp
@@ -242,3 +242,6 @@ float min_loc(const cv::Mat_<cv::Vec3f> &points, cv::Vec2f &loc, cv::Vec3f &out,
 QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMeta*> &surfs_v, const nlohmann::json &params, float voxelsize = 1.0);
 float pointTo(cv::Vec2f &loc, const cv::Mat_<cv::Vec3d> &points, const cv::Vec3f &tgt, float th, int max_iters, float scale);
 float pointTo(cv::Vec2f &loc, const cv::Mat_<cv::Vec3f> &points, const cv::Vec3f &tgt, float th, int max_iters, float scale);
+
+void write_overlapping_json(const std::filesystem::path& seg_path, const std::set<std::string>& overlapping_names);
+std::set<std::string> read_overlapping_json(const std::filesystem::path& seg_path);

--- a/core/src/Surface.cpp
+++ b/core/src/Surface.cpp
@@ -1550,6 +1550,12 @@ SurfaceMeta::~SurfaceMeta()
 
 void SurfaceMeta::readOverlapping()
 {
+    if (std::filesystem::exists(path / "overlapping")) {
+        throw std::runtime_error(
+            "Found overlapping directory at: " + (path / "overlapping").string() +
+            "\nPlease run overlapping_to_json.py on " +  path.parent_path().string() + " to convert it to JSON format"
+        );
+    }
     overlapping_str = read_overlapping_json(path);
 }
 

--- a/core/src/Surface.cpp
+++ b/core/src/Surface.cpp
@@ -14,6 +14,33 @@
 #include <unordered_map>
 #include <nlohmann/json.hpp>
 
+void write_overlapping_json(const fs::path& seg_path, const std::set<std::string>& overlapping_names) {
+    nlohmann::json overlap_json;
+    overlap_json["overlapping"] = std::vector<std::string>(overlapping_names.begin(), overlapping_names.end());
+
+    std::ofstream o(seg_path / "overlapping.json");
+    o << std::setw(4) << overlap_json << std::endl;
+}
+
+std::set<std::string> read_overlapping_json(const fs::path& seg_path) {
+    std::set<std::string> overlapping;
+    fs::path json_path = seg_path / "overlapping.json";
+
+    if (fs::exists(json_path)) {
+        std::ifstream i(json_path);
+        nlohmann::json overlap_json;
+        i >> overlap_json;
+
+        if (overlap_json.contains("overlapping")) {
+            for (const auto& name : overlap_json["overlapping"]) {
+                overlapping.insert(name.get<std::string>());
+            }
+        }
+    }
+
+    return overlapping;
+}
+
 namespace fs = std::filesystem;
 
 cv::Vec2f offsetPoint2d(TrivialSurfacePointer *ptr, const cv::Vec3f &offset)
@@ -1523,9 +1550,7 @@ SurfaceMeta::~SurfaceMeta()
 
 void SurfaceMeta::readOverlapping()
 {
-    if (std::filesystem::exists(path / "overlapping"))
-        for (const auto& entry : fs::directory_iterator(path / "overlapping"))
-            overlapping_str.insert(entry.path().filename());
+    overlapping_str = read_overlapping_json(path);
 }
 
 QuadSurface *SurfaceMeta::surface()

--- a/scripts/overlapping_to_json.py
+++ b/scripts/overlapping_to_json.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+Script to convert overlapping directories to overlapping.json files
+Usage: python migrate_overlapping_to_json.py ~/PHerc332.volpkg/paths/
+"""
+
+import os
+import json
+import argparse
+import shutil
+from pathlib import Path
+from typing import List, Set
+
+def get_overlapping_names(overlap_dir: Path) -> List[str]:
+    """Get all filenames from the overlapping directory."""
+    names = []
+    if overlap_dir.exists() and overlap_dir.is_dir():
+        for entry in overlap_dir.iterdir():
+            if entry.is_file() or entry.is_dir():
+                names.append(entry.name)
+    return sorted(names)  # Sort for consistent output
+
+def write_overlapping_json(segment_dir: Path, names: List[str]) -> None:
+    """Write overlapping names to JSON file."""
+    json_path = segment_dir / "overlapping.json"
+    data = {"overlapping": names}
+
+    with open(json_path, 'w') as f:
+        json.dump(data, f, indent=4)
+
+    print(f"  Created {json_path} with {len(names)} entries")
+
+def migrate_segment(segment_dir: Path, keep_old: bool = False) -> tuple[bool, bool]:
+    """Migrate a single segment directory. Returns (migrated, removed_dir)."""
+    overlap_dir = segment_dir / "overlapping"
+    json_path = segment_dir / "overlapping.json"
+    migrated = False
+    removed_dir = False
+
+    # Skip if no overlapping directory exists
+    if not overlap_dir.exists():
+        return False, False
+
+    # If JSON doesn't exist, create it
+    if not json_path.exists():
+        # Get overlapping names
+        names = get_overlapping_names(overlap_dir)
+
+        if not names:
+            print(f"  {segment_dir.name}: empty overlapping directory, skipping...")
+        else:
+            # Write JSON file
+            print(f"  {segment_dir.name}:")
+            write_overlapping_json(segment_dir, names)
+            migrated = True
+    else:
+        print(f"  {segment_dir.name}: overlapping.json already exists")
+
+    # Remove old directory by default (unless --keep-old is specified)
+    if overlap_dir.exists() and not keep_old:
+        try:
+            shutil.rmtree(overlap_dir)
+            print(f"  Removed old directory: {overlap_dir}")
+            removed_dir = True
+        except Exception as e:
+            print(f"  Warning: Could not remove {overlap_dir}: {e}")
+
+    return migrated, removed_dir
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Convert overlapping directories to overlapping.json files'
+    )
+    parser.add_argument(
+        'path',
+        type=str,
+        help='Base path containing segment directories (e.g., ~/PHerc332.volpkg/paths/)'
+    )
+    parser.add_argument(
+        '--keep-old',
+        action='store_true',
+        help='Keep old overlapping directories after conversion (by default they are removed)'
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Show what would be done without making changes'
+    )
+    parser.add_argument(
+        '--update',
+        action='store_true',
+        help='Update existing overlapping.json files'
+    )
+
+    args = parser.parse_args()
+
+    # Expand ~ in path
+    base_path = Path(args.path).expanduser()
+
+    if not base_path.exists():
+        print(f"Error: Path does not exist: {base_path}")
+        return 1
+
+    if not base_path.is_dir():
+        print(f"Error: Path is not a directory: {base_path}")
+        return 1
+
+    print(f"Scanning for segment directories in: {base_path}")
+
+    migrated_count = 0
+    skipped_count = 0
+    error_count = 0
+    removed_count = 0
+    cleanup_only_count = 0
+
+    # Find all subdirectories
+    segment_dirs = [d for d in base_path.iterdir() if d.is_dir()]
+
+    print(f"Found {len(segment_dirs)} subdirectories")
+
+    for segment_dir in sorted(segment_dirs):
+        overlap_dir = segment_dir / "overlapping"
+        json_path = segment_dir / "overlapping.json"
+
+        # Check if this looks like a segment directory with overlapping data
+        if not overlap_dir.exists() and not json_path.exists():
+            continue
+
+        # Also process if we just need to remove a directory
+        if json_path.exists() and overlap_dir.exists() and not args.update:
+            # Just need to clean up the directory
+            if not args.keep_old:
+                try:
+                    if args.dry_run:
+                        print(f"{segment_dir.name}: has both JSON and directory")
+                        print(f"  Would remove directory: {overlap_dir}")
+                        cleanup_only_count += 1
+                    else:
+                        shutil.rmtree(overlap_dir)
+                        print(f"{segment_dir.name}: Removed old directory: {overlap_dir}")
+                        removed_count += 1
+                        cleanup_only_count += 1
+                except Exception as e:
+                    print(f"  Warning: Could not remove {overlap_dir}: {e}")
+                    error_count += 1
+            continue
+
+        try:
+            if args.dry_run:
+                if overlap_dir.exists():
+                    names = get_overlapping_names(overlap_dir)
+                    if not json_path.exists() and names:
+                        print(f"Would migrate {segment_dir.name} ({len(names)} overlaps)")
+                        migrated_count += 1
+                    elif json_path.exists():
+                        print(f"{segment_dir.name}: has both JSON and directory")
+                    else:
+                        print(f"Would skip {segment_dir.name} (empty overlapping dir)")
+                        skipped_count += 1
+
+                    if not args.keep_old:
+                        print(f"  Would remove directory: {overlap_dir}")
+                elif json_path.exists() and args.update:
+                    print(f"Would update {segment_dir.name}")
+                    migrated_count += 1
+                else:
+                    skipped_count += 1
+            else:
+                # Handle updates
+                if json_path.exists() and args.update and overlap_dir.exists():
+                    names = get_overlapping_names(overlap_dir)
+                    if names:
+                        print(f"  Updating {segment_dir.name}:")
+                        write_overlapping_json(segment_dir, names)
+                        migrated_count += 1
+                    else:
+                        skipped_count += 1
+
+                    # Always try to remove directory if not keeping old
+                    if overlap_dir.exists() and not args.keep_old:
+                        try:
+                            shutil.rmtree(overlap_dir)
+                            print(f"  Removed old directory: {overlap_dir}")
+                            removed_count += 1
+                        except Exception as e:
+                            print(f"  Warning: Could not remove {overlap_dir}: {e}")
+                else:
+                    # Normal migration and/or directory removal
+                    was_migrated, was_removed = migrate_segment(segment_dir, args.keep_old)
+                    if was_migrated:
+                        migrated_count += 1
+                    else:
+                        skipped_count += 1
+                    if was_removed:
+                        removed_count += 1
+
+        except Exception as e:
+            print(f"  Error processing {segment_dir.name}: {e}")
+            error_count += 1
+
+    # Summary
+    print("\nSummary:")
+    print(f"  Migrated: {migrated_count}")
+    if cleanup_only_count > 0:
+        print(f"  Cleanup only: {cleanup_only_count}")
+    print(f"  Skipped: {skipped_count}")
+    print(f"  Errors: {error_count}")
+    if removed_count > 0:
+        print(f"  Total directories removed: {removed_count}")
+
+    if args.dry_run:
+        print("\nThis was a dry run. No changes were made.")
+        print("Run without --dry-run to perform the migration.")
+    elif args.keep_old:
+        print("\nOld overlapping directories were kept. Run without --keep-old to remove them.")
+
+    return 0
+
+if __name__ == "__main__":
+    exit(main())


### PR DESCRIPTION
Patches currently have an `overlapping` directory that has a list of 0 length files in it denoting any patches that the patch in question overlaps with. This involves a lot of file io, especially when trying to sync things with rsync, which works on a file by file basis. 

This PR changes that to create and use an `overlapping.json` which just has the list as a json list of strings that gets read and written. It also includes a script that can convert an existing `paths/` directory to `overlapping.json`. I tested this out on the scroll3 data from the VC3D tutorial on the website and nothing exploded, but the script is destructive and I remove the old code for reading the directory listing, so users might be advised to backup their volpkg before running this.

It otherwise seems like it works fine though, and overlap filtering seems much faster though I have no benchmarks