### PR TITLE
dev z5 xtensor 0.26+

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -83,7 +83,7 @@ target_link_libraries(vc_fill_quadmesh
     opencv_highgui
     VC::slicing
     VC::surface
-    ceres
+    Ceres::ceres
 )
 
 add_executable(vc_tiffxyz_upscale_grounding src/vc_tiffxyz_upscale_grounding.cpp)
@@ -91,7 +91,7 @@ target_link_libraries(vc_tiffxyz_upscale_grounding
     opencv_highgui
     VC::slicing
     VC::surface
-    ceres
+    Ceres::ceres
 )
 
 ## experiements for flattening ##

--- a/apps/src/ImgToZarr.cpp
+++ b/apps/src/ImgToZarr.cpp
@@ -7,12 +7,12 @@
 #include <jxl/resizable_parallel_runner_cxx.h>
 #include <jxl/types.h>
 
-#include <xtensor/xadapt.hpp>
-#include <xtensor/xview.hpp>
-#include <xtensor/xarray.hpp>
-#include <xtensor/xaxis_slice_iterator.hpp>
-#include <xtensor/xio.hpp>
-#include <xtensor/xbuilder.hpp>
+#include <xtensor/containers/xadapt.hpp>
+#include <xtensor/views/xview.hpp>
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/views/xaxis_slice_iterator.hpp>
+#include <xtensor/io/xio.hpp>
+#include <xtensor/generators/xbuilder.hpp>
 
 #include "z5/factory.hxx"
 #include "z5/filesystem/handle.hxx"

--- a/apps/src/ImgToZarr.cpp
+++ b/apps/src/ImgToZarr.cpp
@@ -7,12 +7,13 @@
 #include <jxl/resizable_parallel_runner_cxx.h>
 #include <jxl/types.h>
 
-#include <xtensor/containers/xadapt.hpp>
-#include <xtensor/views/xview.hpp>
-#include <xtensor/containers/xarray.hpp>
-#include <xtensor/views/xaxis_slice_iterator.hpp>
-#include <xtensor/io/xio.hpp>
-#include <xtensor/generators/xbuilder.hpp>
+#include "vc/core/util/xtensor_include.hpp"
+#include XTENSORINCLUDE(containers, xadapt.hpp)
+#include XTENSORINCLUDE(views, xview.hpp)
+#include XTENSORINCLUDE(containers, xarray.hpp)
+#include XTENSORINCLUDE(views, xaxis_slice_iterator.hpp)
+#include XTENSORINCLUDE(io, xio.hpp)
+#include XTENSORINCLUDE(generators, xbuilder.hpp)
 
 #include "z5/factory.hxx"
 #include "z5/filesystem/handle.hxx"

--- a/apps/src/ObjAlphaCompRefinement.cpp
+++ b/apps/src/ObjAlphaCompRefinement.cpp
@@ -1,10 +1,10 @@
 #include <nlohmann/json.hpp>
 
-#include <xtensor/xarray.hpp>
-#include <xtensor/xaxis_slice_iterator.hpp>
-#include <xtensor/xio.hpp>
-#include <xtensor/xbuilder.hpp>
-#include <xtensor/xview.hpp>
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/views/xaxis_slice_iterator.hpp>
+#include <xtensor/io/xio.hpp>
+#include <xtensor/generators/xbuilder.hpp>
+#include <xtensor/views/xview.hpp>
 
 #include "z5/factory.hxx"
 #include "z5/filesystem/handle.hxx"

--- a/apps/src/ObjAlphaCompRefinement.cpp
+++ b/apps/src/ObjAlphaCompRefinement.cpp
@@ -1,10 +1,11 @@
 #include <nlohmann/json.hpp>
 
-#include <xtensor/containers/xarray.hpp>
-#include <xtensor/views/xaxis_slice_iterator.hpp>
-#include <xtensor/io/xio.hpp>
-#include <xtensor/generators/xbuilder.hpp>
-#include <xtensor/views/xview.hpp>
+#include "vc/core/util/xtensor_include.hpp"
+#include XTENSORINCLUDE(containers, xarray.hpp)
+#include XTENSORINCLUDE(views, xaxis_slice_iterator.hpp)
+#include XTENSORINCLUDE(io, xio.hpp)
+#include XTENSORINCLUDE(generators, xbuilder.hpp)
+#include XTENSORINCLUDE(views, xview.hpp)
 
 #include "z5/factory.hxx"
 #include "z5/filesystem/handle.hxx"

--- a/apps/src/TestChunkedCompute.cpp
+++ b/apps/src/TestChunkedCompute.cpp
@@ -3,7 +3,8 @@
 #include "z5/filesystem/handle.hxx"
 #include "z5/factory.hxx"
 
-#include <xtensor/views/xview.hpp>
+#include "vc/core/util/xtensor_include.hpp"
+#include XTENSORINCLUDE(views, xview.hpp)
 
 #include <opencv2/highgui.hpp>
 

--- a/apps/src/TestChunkedCompute.cpp
+++ b/apps/src/TestChunkedCompute.cpp
@@ -3,7 +3,7 @@
 #include "z5/filesystem/handle.hxx"
 #include "z5/factory.hxx"
 
-#include <xtensor/xview.hpp>
+#include <xtensor/views/xview.hpp>
 
 #include <opencv2/highgui.hpp>
 

--- a/apps/src/ZarrAlphaComp.cpp
+++ b/apps/src/ZarrAlphaComp.cpp
@@ -1,10 +1,10 @@
 #include <nlohmann/json.hpp>
 
-#include <xtensor/xarray.hpp>
-#include <xtensor/xaxis_slice_iterator.hpp>
-#include <xtensor/xio.hpp>
-#include <xtensor/xbuilder.hpp>
-#include <xtensor/xview.hpp>
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/views/xaxis_slice_iterator.hpp>
+#include <xtensor/io/xio.hpp>
+#include <xtensor/generators/xbuilder.hpp>
+#include <xtensor/views/xview.hpp>
 
 #include "z5/factory.hxx"
 #include "z5/filesystem/handle.hxx"

--- a/apps/src/ZarrAlphaComp.cpp
+++ b/apps/src/ZarrAlphaComp.cpp
@@ -1,10 +1,11 @@
 #include <nlohmann/json.hpp>
 
-#include <xtensor/containers/xarray.hpp>
-#include <xtensor/views/xaxis_slice_iterator.hpp>
-#include <xtensor/io/xio.hpp>
-#include <xtensor/generators/xbuilder.hpp>
-#include <xtensor/views/xview.hpp>
+#include "vc/core/util/xtensor_include.hpp"
+#include XTENSORINCLUDE(containers, xarray.hpp)
+#include XTENSORINCLUDE(views, xaxis_slice_iterator.hpp)
+#include XTENSORINCLUDE(io, xio.hpp)
+#include XTENSORINCLUDE(generators, xbuilder.hpp)
+#include XTENSORINCLUDE(views, xview.hpp)
 
 #include "z5/factory.hxx"
 #include "z5/filesystem/handle.hxx"

--- a/apps/src/ZarrExtract.cpp
+++ b/apps/src/ZarrExtract.cpp
@@ -1,10 +1,10 @@
 #include <nlohmann/json.hpp>
 
-#include <xtensor/xarray.hpp>
-#include <xtensor/xaxis_slice_iterator.hpp>
-#include <xtensor/xio.hpp>
-#include <xtensor/xbuilder.hpp>
-#include <xtensor/xview.hpp>
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/views/xaxis_slice_iterator.hpp>
+#include <xtensor/io/xio.hpp>
+#include <xtensor/generators/xbuilder.hpp>
+#include <xtensor/views/xview.hpp>
 
 #include "z5/factory.hxx"
 #include "z5/filesystem/handle.hxx"

--- a/apps/src/ZarrExtract.cpp
+++ b/apps/src/ZarrExtract.cpp
@@ -1,10 +1,11 @@
 #include <nlohmann/json.hpp>
 
-#include <xtensor/containers/xarray.hpp>
-#include <xtensor/views/xaxis_slice_iterator.hpp>
-#include <xtensor/io/xio.hpp>
-#include <xtensor/generators/xbuilder.hpp>
-#include <xtensor/views/xview.hpp>
+#include "vc/core/util/xtensor_include.hpp"
+#include XTENSORINCLUDE(containers, xarray.hpp)
+#include XTENSORINCLUDE(views, xaxis_slice_iterator.hpp)
+#include XTENSORINCLUDE(io, xio.hpp)
+#include XTENSORINCLUDE(generators, xbuilder.hpp)
+#include XTENSORINCLUDE(views, xview.hpp)
 
 #include "z5/factory.hxx"
 #include "z5/filesystem/handle.hxx"

--- a/apps/src/ZarrRenderBlur.cpp
+++ b/apps/src/ZarrRenderBlur.cpp
@@ -1,10 +1,10 @@
 #include <nlohmann/json.hpp>
 
-#include <xtensor/xarray.hpp>
-#include <xtensor/xaxis_slice_iterator.hpp>
-#include <xtensor/xio.hpp>
-#include <xtensor/xbuilder.hpp>
-#include <xtensor/xview.hpp>
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/views/xaxis_slice_iterator.hpp>
+#include <xtensor/io/xio.hpp>
+#include <xtensor/generators/xbuilder.hpp>
+#include <xtensor/views/xview.hpp>
 
 #include "z5/factory.hxx"
 #include "z5/filesystem/handle.hxx"

--- a/apps/src/ZarrRenderBlur.cpp
+++ b/apps/src/ZarrRenderBlur.cpp
@@ -1,10 +1,11 @@
 #include <nlohmann/json.hpp>
 
-#include <xtensor/containers/xarray.hpp>
-#include <xtensor/views/xaxis_slice_iterator.hpp>
-#include <xtensor/io/xio.hpp>
-#include <xtensor/generators/xbuilder.hpp>
-#include <xtensor/views/xview.hpp>
+#include "vc/core/util/xtensor_include.hpp"
+#include XTENSORINCLUDE(containers, xarray.hpp)
+#include XTENSORINCLUDE(views, xaxis_slice_iterator.hpp)
+#include XTENSORINCLUDE(io, xio.hpp)
+#include XTENSORINCLUDE(generators, xbuilder.hpp)
+#include XTENSORINCLUDE(views, xview.hpp)
 
 #include "z5/factory.hxx"
 #include "z5/filesystem/handle.hxx"

--- a/apps/src/vc_grow_seg_from_segments.cpp
+++ b/apps/src/vc_grow_seg_from_segments.cpp
@@ -1,10 +1,10 @@
 #include <nlohmann/json.hpp>
 
-#include <xtensor/xarray.hpp>
-#include <xtensor/xaxis_slice_iterator.hpp>
-#include <xtensor/xio.hpp>
-#include <xtensor/xbuilder.hpp>
-#include <xtensor/xview.hpp>
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/views/xaxis_slice_iterator.hpp>
+#include <xtensor/io/xio.hpp>
+#include <xtensor/generators/xbuilder.hpp>
+#include <xtensor/views/xview.hpp>
 
 #include "z5/factory.hxx"
 #include "z5/filesystem/handle.hxx"

--- a/apps/src/vc_grow_seg_from_segments.cpp
+++ b/apps/src/vc_grow_seg_from_segments.cpp
@@ -1,10 +1,11 @@
 #include <nlohmann/json.hpp>
 
-#include <xtensor/containers/xarray.hpp>
-#include <xtensor/views/xaxis_slice_iterator.hpp>
-#include <xtensor/io/xio.hpp>
-#include <xtensor/generators/xbuilder.hpp>
-#include <xtensor/views/xview.hpp>
+#include "vc/core/util/xtensor_include.hpp"
+#include XTENSORINCLUDE(containers, xarray.hpp)
+#include XTENSORINCLUDE(views, xaxis_slice_iterator.hpp)
+#include XTENSORINCLUDE(io, xio.hpp)
+#include XTENSORINCLUDE(generators, xbuilder.hpp)
+#include XTENSORINCLUDE(views, xview.hpp)
 
 #include "z5/factory.hxx"
 #include "z5/filesystem/handle.hxx"

--- a/apps/src/vc_render_video.cpp
+++ b/apps/src/vc_render_video.cpp
@@ -1,10 +1,10 @@
 #include <nlohmann/json.hpp>
 
-#include <xtensor/xarray.hpp>
-#include <xtensor/xaxis_slice_iterator.hpp>
-#include <xtensor/xio.hpp>
-#include <xtensor/xbuilder.hpp>
-#include <xtensor/xview.hpp>
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/views/xaxis_slice_iterator.hpp>
+#include <xtensor/io/xio.hpp>
+#include <xtensor/generators/xbuilder.hpp>
+#include <xtensor/views/xview.hpp>
 
 #include "z5/factory.hxx"
 #include "z5/filesystem/handle.hxx"

--- a/apps/src/vc_render_video.cpp
+++ b/apps/src/vc_render_video.cpp
@@ -1,10 +1,11 @@
 #include <nlohmann/json.hpp>
 
-#include <xtensor/containers/xarray.hpp>
-#include <xtensor/views/xaxis_slice_iterator.hpp>
-#include <xtensor/io/xio.hpp>
-#include <xtensor/generators/xbuilder.hpp>
-#include <xtensor/views/xview.hpp>
+#include "vc/core/util/xtensor_include.hpp"
+#include XTENSORINCLUDE(containers, xarray.hpp)
+#include XTENSORINCLUDE(views, xaxis_slice_iterator.hpp)
+#include XTENSORINCLUDE(io, xio.hpp)
+#include XTENSORINCLUDE(generators, xbuilder.hpp)
+#include XTENSORINCLUDE(views, xview.hpp)
 
 #include "z5/factory.hxx"
 #include "z5/filesystem/handle.hxx"

--- a/cmake/BuildZ5.cmake
+++ b/cmake/BuildZ5.cmake
@@ -4,7 +4,7 @@ if(VC_BUILD_Z5)
   FetchContent_Declare(
       z5
       GIT_REPOSITORY https://github.com/constantinpape/z5.git
-      GIT_TAG 7df1d21cf3e2ebee8f33f81f67096a71a97d33cd
+      GIT_TAG ee2081bb974fe0d0d702538400c31c38b09f1629
   )
 
   # Populate the project but exclude from all

--- a/cmake/BuildZ5.cmake
+++ b/cmake/BuildZ5.cmake
@@ -4,7 +4,7 @@ if(VC_BUILD_Z5)
   FetchContent_Declare(
       z5
       GIT_REPOSITORY https://github.com/constantinpape/z5.git
-      GIT_TAG ee2081bb974fe0d0d702538400c31c38b09f1629
+      GIT_TAG 7df1d21cf3e2ebee8f33f81f67096a71a97d33cd
   )
 
   # Populate the project but exclude from all

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -47,7 +47,7 @@ target_link_libraries(vc_surface
     PRIVATE
         VC::slicing
         OpenMP::OpenMP_CXX
-        ceres
+        Ceres::ceres
     PUBLIC
         opencv_core
         opencv_video

--- a/core/include/vc/core/types/ChunkedTensor.hpp
+++ b/core/include/vc/core/types/ChunkedTensor.hpp
@@ -5,9 +5,10 @@
 #include <opencv2/core.hpp>
 #include "z5/dataset.hxx"
 
-#include <xtensor/containers/xtensor.hpp>
-#include <xtensor/containers/xadapt.hpp>
-#include <xtensor/views/xview.hpp>
+#include "vc/core/util/xtensor_include.hpp"
+#include XTENSORINCLUDE(containers, xtensor.hpp)
+#include XTENSORINCLUDE(containers, xadapt.hpp)
+#include XTENSORINCLUDE(views, xview.hpp)
 
 #include "z5/multiarray/xtensor_access.hxx"
 

--- a/core/include/vc/core/types/ChunkedTensor.hpp
+++ b/core/include/vc/core/types/ChunkedTensor.hpp
@@ -5,9 +5,9 @@
 #include <opencv2/core.hpp>
 #include "z5/dataset.hxx"
 
-#include <xtensor/xtensor.hpp>
-#include <xtensor/xadapt.hpp>
-#include <xtensor/xview.hpp>
+#include <xtensor/containers/xtensor.hpp>
+#include <xtensor/containers/xadapt.hpp>
+#include <xtensor/views/xview.hpp>
 
 #include "z5/multiarray/xtensor_access.hxx"
 

--- a/core/include/vc/core/util/Slicing.hpp
+++ b/core/include/vc/core/util/Slicing.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <xtensor/containers/xarray.hpp>
+#include "vc/core/util/xtensor_include.hpp"
+#include XTENSORINCLUDE(containers, xarray.hpp)
 #include <opencv2/core.hpp>
 
 #include <shared_mutex>

--- a/core/include/vc/core/util/Slicing.hpp
+++ b/core/include/vc/core/util/Slicing.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <xtensor/xarray.hpp>
+#include <xtensor/containers/xarray.hpp>
 #include <opencv2/core.hpp>
 
 #include <shared_mutex>

--- a/core/include/vc/core/util/SurfaceVoxelizer.hpp
+++ b/core/include/vc/core/util/SurfaceVoxelizer.hpp
@@ -3,7 +3,8 @@
 #include <string>
 #include <map>
 #include <opencv2/core.hpp>
-#include <xtensor/containers/xarray.hpp>
+#include "vc/core/util/xtensor_include.hpp"
+#include XTENSORINCLUDE(containers, xarray.hpp)
 #include "vc/core/util/Surface.hpp"
 
 namespace z5 {

--- a/core/include/vc/core/util/SurfaceVoxelizer.hpp
+++ b/core/include/vc/core/util/SurfaceVoxelizer.hpp
@@ -3,7 +3,7 @@
 #include <string>
 #include <map>
 #include <opencv2/core.hpp>
-#include <xtensor/xarray.hpp>
+#include <xtensor/containers/xarray.hpp>
 #include "vc/core/util/Surface.hpp"
 
 namespace z5 {

--- a/core/include/vc/core/util/xtensor_include.hpp
+++ b/core/include/vc/core/util/xtensor_include.hpp
@@ -1,0 +1,18 @@
+// xtensor_include.hpp
+#pragma once
+
+#if __has_include(<xtensor/xtensor_config.hpp>)
+#include <xtensor/xtensor_config.hpp>
+#elif __has_include(<xtensor/core/xtensor_config.hpp>)
+#include <xtensor/core/xtensor_config.hpp>
+#endif
+
+#define _VC_XTENSOR_STR(x) #x
+#define _VC_XTENSOR_JOIN_PATH(a, b) _VC_XTENSOR_STR(a/b)
+
+#if defined(XTENSOR_VERSION_MAJOR) && defined(XTENSOR_VERSION_MINOR) && (XTENSOR_VERSION_MAJOR > 0 || XTENSOR_VERSION_MINOR >= 25)
+  #define XTENSORINCLUDE(category, file) _VC_XTENSOR_JOIN_PATH(xtensor/category, file)
+#else
+  // Drop the category (e.g. "containers")
+  #define XTENSORINCLUDE(category, file) _VC_XTENSOR_JOIN_PATH(xtensor, file)
+#endif

--- a/core/include/vc/core/util/xtensor_include.hpp
+++ b/core/include/vc/core/util/xtensor_include.hpp
@@ -10,7 +10,7 @@
 #define _VC_XTENSOR_STR(x) #x
 #define _VC_XTENSOR_JOIN_PATH(a, b) _VC_XTENSOR_STR(a/b)
 
-#if defined(XTENSOR_VERSION_MAJOR) && defined(XTENSOR_VERSION_MINOR) && (XTENSOR_VERSION_MAJOR > 0 || XTENSOR_VERSION_MINOR >= 25)
+#if defined(XTENSOR_VERSION_MAJOR) && defined(XTENSOR_VERSION_MINOR) && (XTENSOR_VERSION_MAJOR > 0 || XTENSOR_VERSION_MINOR >= 26)
   #define XTENSORINCLUDE(category, file) _VC_XTENSOR_JOIN_PATH(xtensor/category, file)
 #else
   // Drop the category (e.g. "containers")

--- a/core/src/Slicing.cpp
+++ b/core/src/Slicing.cpp
@@ -2,11 +2,12 @@
 
 #include <nlohmann/json.hpp>
 
-#include <xtensor/containers/xarray.hpp>
-#include <xtensor/views/xaxis_slice_iterator.hpp>
-#include <xtensor/io/xio.hpp>
-#include <xtensor/generators/xbuilder.hpp>
-#include <xtensor/views/xview.hpp>
+#include "vc/core/util/xtensor_include.hpp"
+#include XTENSORINCLUDE(containers, xarray.hpp)
+#include XTENSORINCLUDE(views, xaxis_slice_iterator.hpp)
+#include XTENSORINCLUDE(io, xio.hpp)
+#include XTENSORINCLUDE(generators, xbuilder.hpp)
+#include XTENSORINCLUDE(views, xview.hpp)
 
 #include "z5/factory.hxx"
 #include "z5/filesystem/handle.hxx"

--- a/core/src/Slicing.cpp
+++ b/core/src/Slicing.cpp
@@ -2,11 +2,11 @@
 
 #include <nlohmann/json.hpp>
 
-#include <xtensor/xarray.hpp>
-#include <xtensor/xaxis_slice_iterator.hpp>
-#include <xtensor/xio.hpp>
-#include <xtensor/xbuilder.hpp>
-#include <xtensor/xview.hpp>
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/views/xaxis_slice_iterator.hpp>
+#include <xtensor/io/xio.hpp>
+#include <xtensor/generators/xbuilder.hpp>
+#include <xtensor/views/xview.hpp>
 
 #include "z5/factory.hxx"
 #include "z5/filesystem/handle.hxx"

--- a/core/src/SurfaceHelpers.cpp
+++ b/core/src/SurfaceHelpers.cpp
@@ -11,7 +11,7 @@
 #include "vc/core/types/ChunkedTensor.hpp"
 
 
-#include <xtensor/xview.hpp>
+#include <xtensor/views/xview.hpp>
 
 #include <fstream>
 #include <iostream>

--- a/core/src/SurfaceHelpers.cpp
+++ b/core/src/SurfaceHelpers.cpp
@@ -11,7 +11,8 @@
 #include "vc/core/types/ChunkedTensor.hpp"
 
 
-#include <xtensor/views/xview.hpp>
+#include "vc/core/util/xtensor_include.hpp"
+#include XTENSORINCLUDE(views, xview.hpp)
 
 #include <fstream>
 #include <iostream>

--- a/core/src/Volume.cpp
+++ b/core/src/Volume.cpp
@@ -18,7 +18,7 @@
 #include "z5/factory.hxx"
 #include "z5/multiarray/xtensor_access.hxx"
 
-#include "xtensor/xarray.hpp"
+#include "xtensor/containers/xarray.hpp"
 
 namespace fs = volcart::filesystem;
 

--- a/core/src/Volume.cpp
+++ b/core/src/Volume.cpp
@@ -18,7 +18,8 @@
 #include "z5/factory.hxx"
 #include "z5/multiarray/xtensor_access.hxx"
 
-#include "xtensor/containers/xarray.hpp"
+#include "vc/core/util/xtensor_include.hpp"
+#include XTENSORINCLUDE(containers, xarray.hpp)
 
 namespace fs = volcart::filesystem;
 


### PR DESCRIPTION
enable forward compatibility with new xtensor (0.26+) and z5 versions while keeping it backwards compatible