### PR TITLE
build: add an optional gimp stage to include gimp in the image

### DIFF
--- a/ubuntu-25.04-plucky.Dockerfile
+++ b/ubuntu-25.04-plucky.Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu:plucky
+FROM ubuntu:plucky as base
 
 RUN apt-get update
 RUN apt-get -y upgrade
 RUN apt-get -y install software-properties-common
 RUN add-apt-repository universe
 RUN apt-get update
-RUN apt-get -y install build-essential git cmake 
+RUN apt-get -y install build-essential git cmake
 RUN apt-get -y install qt6-base-dev libboost-system-dev libboost-program-options-dev
 RUN apt-get -y install libceres-dev xtensor-dev libopencv-dev libxsimd-dev libblosc-dev libspdlog-dev
 RUN apt-get -y install libgsl-dev libsdl2-dev libcurl4-openssl-dev
@@ -25,5 +25,10 @@ RUN cpack -G DEB -V
 
 RUN dpkg -i /src/build/pkgs/vc3d*.deb
 
-RUN apt-get -y autoremove
-RUN rm -r /src
+FROM base as gimp
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    gimp \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+FROM base as default


### PR DESCRIPTION
You can use

```
docker build --target gimp ...
```

to build an image that includes gimp. The default is not changed.

(We should consolidate all the dockerfiles to make it easier to maintain for different requirements)