### PR TITLE
Get VC3D compiling on OSX with minimal from source dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ include(CMakeDependentOption)
 
 set(VC_VERSION 3.0.2)
 
-list(PREPEND CMAKE_PREFIX_PATH "/home/forrest/ceres-install")
+list(PREPEND CMAKE_PREFIX_PATH "$ENV{HOME}/vc-dependencies")
 
 option(VC_VERSION_DATESTAMP "Append date stamp to version number" off)
 if(VC_VERSION_DATESTAMP)
@@ -18,7 +18,7 @@ set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
-set(CMAKE_CXX_FLAGS " -Wno-narrowing -std=c++20" )
+set(CMAKE_CXX_FLAGS " -Wno-narrowing -std=c++20 -DWITH_BLOSC=1 -DWITH_ZLIB=1" )
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb -Og  -g3 ")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ include(CMakeDependentOption)
 
 set(VC_VERSION 3.0.2)
 
+list(PREPEND CMAKE_PREFIX_PATH "/home/forrest/ceres-install")
+
 option(VC_VERSION_DATESTAMP "Append date stamp to version number" off)
 if(VC_VERSION_DATESTAMP)
 string(TIMESTAMP VC_VERSION_TWEAK "%s")
@@ -16,7 +18,7 @@ set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
-set(CMAKE_CXX_FLAGS " -Wno-narrowing " )
+set(CMAKE_CXX_FLAGS " -Wno-narrowing -std=c++20" )
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb -Og  -g3 ")

--- a/build_from_source.sh
+++ b/build_from_source.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+
+set -e
+
+export CC="ccache clang"
+export CXX="ccache clang++"
+export INSTALL_PREFIX="$HOME/ceres-install"
+export BUILD_DIR="$HOME/ceres-build"
+export JOBS=$(nproc)
+export COMMON_FLAGS="-march=native -w"
+export COMMON_LDFLAGS="-fuse-ld=lld"
+
+sudo apt-get update
+sudo apt-get install -y libgmp-dev libmpfr-dev ccache ninja-build lld \
+    libcurl4-openssl-dev libboost-system-dev libboost-program-options-dev qt6-base-dev
+
+rm -rf "$BUILD_DIR" "$INSTALL_PREFIX"
+mkdir -p "$BUILD_DIR" "$INSTALL_PREFIX"
+cd "$BUILD_DIR"
+
+# nlohmann/json
+rm -rf json
+git clone --depth 1 https://github.com/nlohmann/json.git
+cd json
+mkdir -p build && cd build
+cmake .. -G Ninja \
+    -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_C_FLAGS="${COMMON_FLAGS}" \
+    -DCMAKE_CXX_FLAGS="${COMMON_FLAGS}" \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_EXE_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DCMAKE_SHARED_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DCMAKE_MODULE_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DJSON_BuildTests=OFF
+ninja -j$JOBS
+ninja install
+cd "$BUILD_DIR"
+
+# xtl
+rm -rf xtl
+git clone --depth 1 https://github.com/xtensor-stack/xtl.git
+cd xtl
+mkdir -p build && cd build
+cmake .. -G Ninja \
+    -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_C_FLAGS="${COMMON_FLAGS}" \
+    -DCMAKE_CXX_FLAGS="${COMMON_FLAGS}" \
+    -DCMAKE_EXE_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DCMAKE_SHARED_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DCMAKE_MODULE_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DBUILD_TESTS=OFF
+ninja -j$JOBS
+ninja install
+cd "$BUILD_DIR"
+
+# xsimd
+rm -rf xsimd
+git clone --depth 1 https://github.com/xtensor-stack/xsimd.git
+cd xsimd
+mkdir -p build && cd build
+cmake .. -G Ninja \
+    -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_C_FLAGS="${COMMON_FLAGS}" \
+    -DCMAKE_CXX_FLAGS="${COMMON_FLAGS}" \
+    -DCMAKE_EXE_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DCMAKE_SHARED_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DCMAKE_MODULE_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DENABLE_XTL_COMPLEX=ON \
+    -DBUILD_TESTS=OFF \
+    -DBUILD_BENCHMARK=OFF \
+    -DBUILD_EXAMPLES=OFF \
+    -DXSIMD_SKIP_INSTALL=OFF
+ninja -j$JOBS
+ninja install
+cd "$BUILD_DIR"
+
+# xtensor
+rm -rf xtensor
+git clone --depth 1 https://github.com/xtensor-stack/xtensor.git
+cd xtensor
+mkdir -p build && cd build
+cmake .. -G Ninja \
+    -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_C_FLAGS="${COMMON_FLAGS}" \
+    -DCMAKE_CXX_FLAGS="${COMMON_FLAGS}" \
+    -DCMAKE_EXE_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DCMAKE_SHARED_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DCMAKE_MODULE_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DBUILD_TESTS=OFF \
+    -DXTENSOR_BUILD_TESTS=OFF
+ninja -j$JOBS
+ninja install
+cd "$BUILD_DIR"
+
+# c-blosc
+rm -rf c-blosc
+git clone --depth 1 https://github.com/Blosc/c-blosc.git
+cd c-blosc
+mkdir -p build && cd build
+cmake .. -G Ninja \
+    -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_C_FLAGS="${COMMON_FLAGS}" \
+    -DCMAKE_CXX_FLAGS="${COMMON_FLAGS}" \
+    -DCMAKE_EXE_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DCMAKE_SHARED_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DCMAKE_MODULE_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DBUILD_STATIC=ON \
+    -DBUILD_TESTS=OFF \
+    -DBUILD_BENCHMARKS=OFF
+ninja -j$JOBS
+ninja install
+cd "$BUILD_DIR"
+
+# z5
+rm -rf z5
+git clone --depth 1 https://github.com/SuperOptimizer/z5.git
+cd z5
+mkdir -p build && cd build
+cmake .. -G Ninja \
+    -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_C_FLAGS="${COMMON_FLAGS}" \
+    -DCMAKE_CXX_FLAGS="${COMMON_FLAGS}" \
+    -DCMAKE_EXE_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DCMAKE_SHARED_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DCMAKE_MODULE_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DCMAKE_PREFIX_PATH="$INSTALL_PREFIX" \
+    -DWITH_BLOSC=ON \
+    -DWITH_ZLIB=ON \
+    -DWITH_XZ=ON \
+    -DWITH_LZ4=ON \
+    -DBUILD_Z5PY=OFF \
+    -DBUILD_TESTS=OFF
+ninja -j$JOBS
+ninja install
+cd "$BUILD_DIR"
+
+# spdlog
+rm -rf spdlog
+git clone --depth 1 https://github.com/gabime/spdlog.git
+cd spdlog
+mkdir -p build && cd build
+cmake .. -G Ninja \
+    -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_C_FLAGS="${COMMON_FLAGS}" \
+    -DCMAKE_CXX_FLAGS="${COMMON_FLAGS}" \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_EXE_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DCMAKE_SHARED_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DCMAKE_MODULE_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DSPDLOG_BUILD_EXAMPLE=OFF \
+    -DSPDLOG_BUILD_TESTS=OFF \
+    -DSPDLOG_INSTALL=ON \
+    -DSPDLOG_FMT_EXTERNAL=OFF
+ninja -j$JOBS
+ninja install
+cd "$BUILD_DIR"
+
+# Ceres Solver
+rm -rf ceres-solver
+git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/ceres-solver/ceres-solver.git
+cd ceres-solver
+mkdir -p build && cd build
+
+cmake .. -G Ninja \
+    -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_C_FLAGS="${COMMON_FLAGS} -g0" \
+    -DCMAKE_CXX_FLAGS="${COMMON_FLAGS} -g0" \
+    -DCMAKE_EXE_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DCMAKE_SHARED_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DCMAKE_MODULE_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DBUILD_TESTING=OFF \
+    -DEIGEN_BUILD_DOC=OFF \
+    -DSUITESPARSE=ON \
+    -DLAPACK=ON \
+    -DEIGENSPARSE=ON \
+    -DEIGENMETIS=ON \
+    -DSCHUR_SPECIALIZATIONS=ON \
+    -DMINIGLOG=ON \
+    -DUSE_CUDA=OFF
+
+ninja -j$JOBS
+ninja install

--- a/build_from_source.sh
+++ b/build_from_source.sh
@@ -10,9 +10,19 @@ export JOBS=$(nproc)
 export COMMON_FLAGS="-march=native -w"
 export COMMON_LDFLAGS="-fuse-ld=lld"
 
-#sudo apt-get update
-#sudo apt-get install -y libgmp-dev libmpfr-dev ccache ninja-build lld \
-#    libcurl4-openssl-dev libboost-system-dev libboost-program-options-dev qt6-base-dev
+if [[ "$(uname)" == "Darwin" ]]; then
+    echo "Running on macOS"
+    #todo: determine the complete list
+    brew install qt cmake clang boost eigen
+elif [[ "$(uname)" == "Linux" ]]; then
+    echo "Running on Linux"
+    sudo apt-get update
+    #todo: determine the complete list
+    sudo apt-get install -y libgmp-dev libmpfr-dev ccache ninja-build lld \
+        libcurl4-openssl-dev libboost-system-dev libboost-program-options-dev qt6-base-dev
+fi
+
+
 
 rm -rf "$BUILD_DIR" "$INSTALL_PREFIX"
 mkdir -p "$BUILD_DIR" "$INSTALL_PREFIX"

--- a/build_from_source.sh
+++ b/build_from_source.sh
@@ -4,15 +4,15 @@ set -e
 
 export CC="ccache clang"
 export CXX="ccache clang++"
-export INSTALL_PREFIX="$HOME/ceres-install"
-export BUILD_DIR="$HOME/ceres-build"
+export INSTALL_PREFIX="$HOME/vc-dependencies"
+export BUILD_DIR="$HOME/vc-dependencies-build"
 export JOBS=$(nproc)
 export COMMON_FLAGS="-march=native -w"
 export COMMON_LDFLAGS="-fuse-ld=lld"
 
-sudo apt-get update
-sudo apt-get install -y libgmp-dev libmpfr-dev ccache ninja-build lld \
-    libcurl4-openssl-dev libboost-system-dev libboost-program-options-dev qt6-base-dev
+#sudo apt-get update
+#sudo apt-get install -y libgmp-dev libmpfr-dev ccache ninja-build lld \
+#    libcurl4-openssl-dev libboost-system-dev libboost-program-options-dev qt6-base-dev
 
 rm -rf "$BUILD_DIR" "$INSTALL_PREFIX"
 mkdir -p "$BUILD_DIR" "$INSTALL_PREFIX"
@@ -160,8 +160,6 @@ cmake .. -G Ninja \
     -DCMAKE_PREFIX_PATH="$INSTALL_PREFIX" \
     -DWITH_BLOSC=ON \
     -DWITH_ZLIB=ON \
-    -DWITH_XZ=ON \
-    -DWITH_LZ4=ON \
     -DBUILD_Z5PY=OFF \
     -DBUILD_TESTS=OFF
 ninja -j$JOBS
@@ -194,11 +192,55 @@ ninja -j$JOBS
 ninja install
 cd "$BUILD_DIR"
 
+
+# OpenCV
+rm -rf opencv
+git clone --depth 1 https://github.com/opencv/opencv.git
+cd opencv
+mkdir -p build && cd build
+cmake .. -G Ninja \
+    -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_C_FLAGS="${COMMON_FLAGS}" \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_CXX_FLAGS="${COMMON_FLAGS}" \
+    -DCMAKE_EXE_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DCMAKE_SHARED_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DCMAKE_MODULE_LINKER_FLAGS="${COMMON_LDFLAGS}" \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DBUILD_opencv_apps=OFF \
+    -DBUILD_opencv_python2=OFF \
+    -DBUILD_opencv_python3=OFF \
+    -DBUILD_TESTS=OFF \
+    -DBUILD_PERF_TESTS=OFF \
+    -DBUILD_EXAMPLES=OFF \
+    -DBUILD_DOCS=OFF \
+    -DWITH_CUDA=OFF \
+    -DWITH_OPENMP=OFF \
+    -DWITH_TBB=OFF \
+    -DWITH_IPP=OFF \
+    -DWITH_VTK=OFF \
+    -DWITH_FFMPEG=ON \
+    -DWITH_GSTREAMER=OFF \
+    -DWITH_V4L=ON \
+    -DWITH_QT=OFF \
+    -DWITH_GTK=OFF \
+    -DWITH_OPENCL=ON \
+    -DWITH_OPENEXR=OFF \
+    -DOPENCV_ENABLE_NONFREE=ON
+ninja -j$JOBS
+ninja install
+cd "$BUILD_DIR"
+
 # Ceres Solver
 rm -rf ceres-solver
 git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/ceres-solver/ceres-solver.git
 cd ceres-solver
-mkdir -p build && cd build
+mkdir -p ceresbuild && cd ceresbuild
 
 cmake .. -G Ninja \
     -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \

--- a/cmake/BuildZ5.cmake
+++ b/cmake/BuildZ5.cmake
@@ -1,4 +1,4 @@
-option(VC_BUILD_Z5 "Build in-source z5 header only library" on)
+option(VC_BUILD_Z5 "Build in-source z5 header only library" off)
 if(VC_BUILD_Z5)
   # Declare the project
   FetchContent_Declare(

--- a/cmake/BuildZ5.cmake
+++ b/cmake/BuildZ5.cmake
@@ -1,4 +1,4 @@
-option(VC_BUILD_Z5 "Build in-source z5 header only library" off)
+option(VC_BUILD_Z5 "Build in-source z5 header only library" on)
 if(VC_BUILD_Z5)
   # Declare the project
   FetchContent_Declare(


### PR DESCRIPTION
There was an ask on discord to get vc3d compiling on OSX. We could already do it with docker but this allows to compile natively with just brew and some compiling from source.

I also think this approach is best; if you're run the accompanying script then dependencies will get pulled from $HOME/vc-dependencies. If you haven't then the build proceeds as normal and just expects that everything has been apt installed correctly

This also gets my vc3d compilation actually working on both osx and ubuntu 25.10. I ran into different issues on both operating systems
- a `glog` / `google log` conflict. It seems like the library was getting linked twice in multiple ceres solver dependencies? I don't really know, but I've configured ceres-solver to not use it on both operating systems. opencv seems to depend on it on osx only for some unknown reason so I build opencv from source
- an xtl / xtensor / z5 / xarray issue with the different header paths