### PR TITLE
add runtime check for cuda sparse

### DIFF
--- a/core/src/SurfaceHelpers.cpp
+++ b/core/src/SurfaceHelpers.cpp
@@ -847,7 +847,6 @@ float local_optimization(int radius, const cv::Vec2i &p, cv::Mat_<uint8_t> &stat
 //        options.use_inner_iterations = true;
 //    }
 #ifdef VC_USE_CUDA_SPARSE
-    options.sparse_linear_algebra_library_type = ceres::CUDA_SPARSE;
     // Check if Ceres was actually built with CUDA sparse support
     if (ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::CUDA_SPARSE)) {
         options.linear_solver_type = ceres::SPARSE_SCHUR;
@@ -1123,7 +1122,6 @@ QuadSurface *space_tracing_quad_phys(z5::Dataset *ds, float scale, ChunkCache *c
     options_big.linear_solver_type = ceres::SPARSE_SCHUR;
     options_big.use_nonmonotonic_steps = true;
 #ifdef VC_USE_CUDA_SPARSE
-    options.sparse_linear_algebra_library_type = ceres::CUDA_SPARSE;
     // Check if Ceres was actually built with CUDA sparse support
     if (ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::CUDA_SPARSE)) {
         options.linear_solver_type = ceres::SPARSE_SCHUR;
@@ -2269,7 +2267,6 @@ void optimize_surface_mapping(SurfTrackerData &data, cv::Mat_<uint8_t> &state, c
     ceres::Solver::Options options;
     options.linear_solver_type = ceres::SPARSE_SCHUR;
 #ifdef VC_USE_CUDA_SPARSE
-    options.sparse_linear_algebra_library_type = ceres::CUDA_SPARSE;
     // Check if Ceres was actually built with CUDA sparse support
     if (ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::CUDA_SPARSE)) {
         options.linear_solver_type = ceres::SPARSE_SCHUR;

--- a/core/src/SurfaceHelpers.cpp
+++ b/core/src/SurfaceHelpers.cpp
@@ -1124,12 +1124,12 @@ QuadSurface *space_tracing_quad_phys(z5::Dataset *ds, float scale, ChunkCache *c
 #ifdef VC_USE_CUDA_SPARSE
     // Check if Ceres was actually built with CUDA sparse support
     if (ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::CUDA_SPARSE)) {
-        options.linear_solver_type = ceres::SPARSE_SCHUR;
-        options.sparse_linear_algebra_library_type = ceres::CUDA_SPARSE;
+        options_big.linear_solver_type = ceres::SPARSE_SCHUR;
+        options_big.sparse_linear_algebra_library_type = ceres::CUDA_SPARSE;
 
         // Enable mixed precision for SPARSE_SCHUR
-        if (options.linear_solver_type == ceres::SPARSE_SCHUR) {
-            options.use_mixed_precision_solves = true;
+        if (options_big.linear_solver_type == ceres::SPARSE_SCHUR) {
+            options_big.use_mixed_precision_solves = true;
         }
     } else {
         std::cerr << "Warning: CUDA_SPARSE requested but Ceres was not built with CUDA sparse support. Falling back to default solver." << std::endl;

--- a/core/src/SurfaceHelpers.cpp
+++ b/core/src/SurfaceHelpers.cpp
@@ -847,12 +847,18 @@ float local_optimization(int radius, const cv::Vec2i &p, cv::Mat_<uint8_t> &stat
 //        options.use_inner_iterations = true;
 //    }
 #ifdef VC_USE_CUDA_SPARSE
-    options.linear_solver_type = ceres::SPARSE_SCHUR;
     options.sparse_linear_algebra_library_type = ceres::CUDA_SPARSE;
+    // Check if Ceres was actually built with CUDA sparse support
+    if (ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::CUDA_SPARSE)) {
+        options.linear_solver_type = ceres::SPARSE_SCHUR;
+        options.sparse_linear_algebra_library_type = ceres::CUDA_SPARSE;
 
-    // Enable mixed precision for SPARSE_SCHUR
-    if (options.linear_solver_type == ceres::SPARSE_SCHUR) {
-        options.use_mixed_precision_solves = true;
+        // Enable mixed precision for SPARSE_SCHUR
+        if (options.linear_solver_type == ceres::SPARSE_SCHUR) {
+            options.use_mixed_precision_solves = true;
+        }
+    } else {
+        std::cerr << "Warning: CUDA_SPARSE requested but Ceres was not built with CUDA sparse support. Falling back to default solver." << std::endl;
     }
 #endif
     ceres::Solver::Summary summary;
@@ -1117,11 +1123,18 @@ QuadSurface *space_tracing_quad_phys(z5::Dataset *ds, float scale, ChunkCache *c
     options_big.linear_solver_type = ceres::SPARSE_SCHUR;
     options_big.use_nonmonotonic_steps = true;
 #ifdef VC_USE_CUDA_SPARSE
-    options_big.sparse_linear_algebra_library_type = ceres::CUDA_SPARSE;
+    options.sparse_linear_algebra_library_type = ceres::CUDA_SPARSE;
+    // Check if Ceres was actually built with CUDA sparse support
+    if (ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::CUDA_SPARSE)) {
+        options.linear_solver_type = ceres::SPARSE_SCHUR;
+        options.sparse_linear_algebra_library_type = ceres::CUDA_SPARSE;
 
-    // Enable mixed precision for SPARSE_SCHUR
-    if (options_big.linear_solver_type == ceres::SPARSE_SCHUR) {
-        options_big.use_mixed_precision_solves = true;
+        // Enable mixed precision for SPARSE_SCHUR
+        if (options.linear_solver_type == ceres::SPARSE_SCHUR) {
+            options.use_mixed_precision_solves = true;
+        }
+    } else {
+        std::cerr << "Warning: CUDA_SPARSE requested but Ceres was not built with CUDA sparse support. Falling back to default solver." << std::endl;
     }
 #endif
     options_big.minimizer_progress_to_stdout = false;
@@ -2257,7 +2270,18 @@ void optimize_surface_mapping(SurfTrackerData &data, cv::Mat_<uint8_t> &state, c
     options.linear_solver_type = ceres::SPARSE_SCHUR;
 #ifdef VC_USE_CUDA_SPARSE
     options.sparse_linear_algebra_library_type = ceres::CUDA_SPARSE;
-    options.use_mixed_precision_solves = true;
+    // Check if Ceres was actually built with CUDA sparse support
+    if (ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::CUDA_SPARSE)) {
+        options.linear_solver_type = ceres::SPARSE_SCHUR;
+        options.sparse_linear_algebra_library_type = ceres::CUDA_SPARSE;
+
+        // Enable mixed precision for SPARSE_SCHUR
+        if (options.linear_solver_type == ceres::SPARSE_SCHUR) {
+            options.use_mixed_precision_solves = true;
+        }
+    } else {
+        std::cerr << "Warning: CUDA_SPARSE requested but Ceres was not built with CUDA sparse support. Falling back to default solver." << std::endl;
+    }
 #endif
     options.minimizer_progress_to_stdout = false;
     options.max_num_iterations = 100;


### PR DESCRIPTION
previously it was possible to build w/ vc_use_cuda_sparse but _not_ have cuda sparse available, which will throw an error but not stop the trace, which leads to a situation where your trace has no opt but you might not notice