### PR TITLE
add a switch to only display the current segment overlay

### DIFF
--- a/apps/VC3D/CWindow.hpp
+++ b/apps/VC3D/CWindow.hpp
@@ -204,6 +204,7 @@ private:
     QCheckBox* chkFilterNoExpansion;
     QCheckBox* chkFilterNoDefective;
     QCheckBox* chkFilterPartialReview;
+    QCheckBox* chkFilterCurrentOnly;
     QComboBox* cmbSegmentationDir;
     
     QCheckBox* _chkApproved;
@@ -253,6 +254,8 @@ private:
     QShortcut* fDefectiveShortcut;
     QShortcut* fDrawingModeShortcut;
     QShortcut* fCompositeViewShortcut;
+
+
 };  // class CWindow
 
 }  // namespace ChaoVis

--- a/apps/VC3D/VCMain.ui
+++ b/apps/VC3D/VCMain.ui
@@ -425,6 +425,13 @@
                  </property>
                 </widget>
                </item>
+               <item row="3" column="1">
+                <widget class="QCheckBox" name="chkFilterCurrentOnly">
+                 <property name="text">
+                  <string>Current Segment Only</string>
+                 </property>
+                </widget>
+               </item>
               </layout>
              </item>
             </layout>


### PR DESCRIPTION
drawing and redrawing all of the intersections takes a long time and makes the UI laggy in some cases. I'm trying to fix that, but that's taking a fair amount of work, so this switch just disables rendering the surface overlays except for the currently selected segment