### PR TITLE
Fix filtering and z slice navigation

### DIFF
--- a/apps/VC3D/CVolumeViewer.cpp
+++ b/apps/VC3D/CVolumeViewer.cpp
@@ -160,52 +160,32 @@ void CVolumeViewer::onCursorMove(QPointF scene_loc)
     if (!_surf || !_surf_col)
         return;
 
+    // Quick visual feedback only - don't update POI
     cv::Vec3f p, n;
     if (!scene2vol(p, n, _surf, _surf_name, _surf_col, scene_loc, _vis_center, _scale)) {
         if (_cursor) _cursor->hide();
-        return;
-    }
-    if (_cursor) _cursor->show();
+    } else {
+        if (_cursor) {
+            _cursor->show();
+            // Update cursor position visually without POI
+            PlaneSurface *plane = dynamic_cast<PlaneSurface*>(_surf);
+            QuadSurface *quad = dynamic_cast<QuadSurface*>(_surf);
+            cv::Vec3f sp;
 
-    // Standard cursor update
-    POI *cursor = _surf_col->poi("cursor");
-    if (!cursor)
-        cursor = new POI;
-    
-    cursor->p = p;
-    
-    _surf_col->setPOI("cursor", cursor);
-
-    // Point highlighting logic
-    if (!_point_collection) return;
-
-    uint64_t old_highlighted_id = _highlighted_point_id;
-    _highlighted_point_id = 0;
-
-    if (_dragged_point_id == 0) { // Only highlight if not dragging
-        const float highlight_dist_threshold = 10.0f; // pixels
-        float min_dist_sq = highlight_dist_threshold * highlight_dist_threshold;
-
-        for (const auto& item_pair : _points_items) {
-            auto item = item_pair.second.circle;
-            QPointF point_scene_pos = item->rect().center();
-            QPointF diff = scene_loc - point_scene_pos;
-            float dist_sq = QPointF::dotProduct(diff, diff);
-            if (dist_sq < min_dist_sq) {
-                min_dist_sq = dist_sq;
-                _highlighted_point_id = item_pair.first;
+            if (plane) {
+                sp = plane->project(p, 1.0, _scale);
+            } else if (quad) {
+                SurfacePointer *ptr = quad->pointer();
+                _surf->pointTo(ptr, p, 4.0, 100);
+                sp = _surf->loc(ptr) * _scale;
             }
+            _cursor->setPos(sp[0], sp[1]);
         }
     }
 
-    if (old_highlighted_id != _highlighted_point_id) {
-        if (auto old_point = _point_collection->getPoint(old_highlighted_id)) {
-            renderOrUpdatePoint(*old_point);
-        }
-        if (auto new_point = _point_collection->getPoint(_highlighted_point_id)) {
-            renderOrUpdatePoint(*new_point);
-        }
-    }
+    // Defer POI update
+    _overlayUpdateTimer->stop();
+    _overlayUpdateTimer->start();
 }
 
 void CVolumeViewer::recalcScales()
@@ -239,32 +219,28 @@ void CVolumeViewer::recalcScales()
 
 void CVolumeViewer::onZoom(int steps, QPointF scene_loc, Qt::KeyboardModifiers modifiers)
 {
-    // Hide overlays immediately for smooth interaction
-    for(auto &col : _intersect_items)
-        for(auto &item : col.second)
-            item->setVisible(false);
-
     if (!_surf)
         return;
 
+
     if (modifiers & Qt::ShiftModifier) {
-        // Z slice navigation
+        // Z slice navigation - NO POI UPDATES HERE
         int adjustedSteps = steps;
         if (_surf_name == "segmentation") {
             adjustedSteps = (steps > 0) ? 1 : -1;
         }
 
-        _z_off += adjustedSteps;
-
-        POI *poi = _surf_col->poi("focus");
-        if (poi && volume) {
-            int newZ = static_cast<int>(poi->p[2] + adjustedSteps);
-            newZ = std::max(0, std::min(newZ, static_cast<int>(volume->numSlices() - 1)));
-            poi->p[2] = newZ;
-            _surf_col->setPOI("focus", poi);
-            emit sendZSliceChanged(newZ);
+        // ONLY update plane origin directly for immediate visual feedback
+        if (auto* plane = dynamic_cast<PlaneSurface*>(_surf)) {
+            cv::Vec3f origin = plane->origin();
+            origin[2] += adjustedSteps;
+            if (volume) {
+                origin[2] = std::max(0.0f, std::min(origin[2], static_cast<float>(volume->numSlices() - 1)));
+            }
+            plane->setOrigin(origin);
         }
 
+        _z_off = 0;
         renderVisible(true);
     }
     else {
@@ -273,31 +249,24 @@ void CVolumeViewer::onZoom(int steps, QPointF scene_loc, Qt::KeyboardModifiers m
         round_scale(_scale);
         recalcScales();
 
-        // Cache the view-space mouse position; used later for cursor update
-        QPoint pointViewportBefore = fGraphicsView->mapFromScene(scene_loc);
-
         // The above scale is *not* part of Qt's scene-to-view transform, but part of the voxel-to-scene transform
         // implemented in PlaneSurface::project; it causes a zoom around the surface origin
         // Translations are represented in the Qt scene-to-view transform; these move the surface origin within the viewpoint
         // To zoom centered on the mouse, we adjust the scene-to-view translation appropriately
         // If the mouse were at the plane/surface origin, this adjustment should be zero
         // If the mouse were right of the plane origin, should translate to the left so that point ends up where it was
-        fGraphicsView->translate(scene_loc.x() * (1 - zoom), scene_loc.y() * (1 - zoom));
-
-        // Update the cursor (which lives in scene space) to still lie under the mouse even after the above translation
-        QPointF pointSceneAfter = fGraphicsView->mapToScene(pointViewportBefore);
-        onCursorMove(pointSceneAfter);
+        fGraphicsView->translate(scene_loc.x() * (1 - zoom),
+                                scene_loc.y() * (1 - zoom));
 
         curr_img_area = {0,0,0,0};
         int max_size = 100000;
         fGraphicsView->setSceneRect(-max_size/2, -max_size/2, max_size, max_size);
 
-        renderVisible(); // Immediate render for smooth zooming
+        renderVisible();
     }
 
     _lbl->setText(QString("%1x %2").arg(_scale).arg(_z_off));
 
-    // Defer all overlay updates
     _overlayUpdateTimer->stop();
     _overlayUpdateTimer->start();
 }
@@ -934,9 +903,7 @@ void CVolumeViewer::renderIntersections()
         _intersect_items.erase(key);
 
     PlaneSurface *plane = dynamic_cast<PlaneSurface*>(_surf);
-    
-    if (_z_off)
-        return;
+
     
     if (plane) {
         cv::Rect plane_roi = {curr_img_area.x()/_scale, curr_img_area.y()/_scale, curr_img_area.width()/_scale, curr_img_area.height()/_scale};
@@ -1132,27 +1099,23 @@ void CVolumeViewer::renderIntersections()
 }
 
 
-void CVolumeViewer::onPanRelease(Qt::MouseButton buttons, Qt::KeyboardModifiers modifiers)
+void CVolumeViewer::onPanStart(Qt::MouseButton buttons, Qt::KeyboardModifiers modifiers)
 {
-    renderVisible(); // Immediate render
+    renderVisible();  // Immediate render
 
     // Defer overlay updates
     _overlayUpdateTimer->stop();
     _overlayUpdateTimer->start();
 }
 
-void CVolumeViewer::onPanStart(Qt::MouseButton buttons, Qt::KeyboardModifiers modifiers)
+// Modified onPanRelease
+void CVolumeViewer::onPanRelease(Qt::MouseButton buttons, Qt::KeyboardModifiers modifiers)
 {
-    renderVisible(); // Immediate render
+    renderVisible();  // Final render
 
-    // Hide overlays for smooth panning
-    for(auto &col : _intersect_items)
-        for(auto &item : col.second)
-            item->setVisible(false);
-
-    // Defer overlay updates
+    // Stop timer and force immediate overlay update
     _overlayUpdateTimer->stop();
-    _overlayUpdateTimer->start();
+    updateAllOverlays();
 }
 
 void CVolumeViewer::onScrolled()
@@ -1745,6 +1708,59 @@ void CVolumeViewer::setResetViewOnSurfaceChange(bool reset)
 
 void CVolumeViewer::updateAllOverlays()
 {
+    if (auto* plane = dynamic_cast<PlaneSurface*>(_surf)) {
+        POI *poi = _surf_col->poi("focus");
+        if (poi) {
+            cv::Vec3f planeOrigin = plane->origin();
+            // If plane origin differs from POI, update POI
+            if (std::abs(poi->p[2] - planeOrigin[2]) > 0.01) {
+                poi->p = planeOrigin;
+                _surf_col->setPOI("focus", poi);  // NOW we do the expensive update
+                emit sendZSliceChanged(static_cast<int>(poi->p[2]));
+            }
+        }
+    }
+
+    QPoint viewportPos = fGraphicsView->mapFromGlobal(QCursor::pos());
+    QPointF scenePos = fGraphicsView->mapToScene(viewportPos);
+
+    cv::Vec3f p, n;
+    if (scene2vol(p, n, _surf, _surf_name, _surf_col, scenePos, _vis_center, _scale)) {
+        POI *cursor = _surf_col->poi("cursor");
+        if (!cursor)
+            cursor = new POI;
+        cursor->p = p;
+        _surf_col->setPOI("cursor", cursor);
+    }
+
+    if (_point_collection && _dragged_point_id == 0) {
+        uint64_t old_highlighted_id = _highlighted_point_id;
+        _highlighted_point_id = 0;
+
+        const float highlight_dist_threshold = 10.0f;
+        float min_dist_sq = highlight_dist_threshold * highlight_dist_threshold;
+
+        for (const auto& item_pair : _points_items) {
+            auto item = item_pair.second.circle;
+            QPointF point_scene_pos = item->rect().center();
+            QPointF diff = scenePos - point_scene_pos;
+            float dist_sq = QPointF::dotProduct(diff, diff);
+            if (dist_sq < min_dist_sq) {
+                min_dist_sq = dist_sq;
+                _highlighted_point_id = item_pair.first;
+            }
+        }
+
+        if (old_highlighted_id != _highlighted_point_id) {
+            if (auto old_point = _point_collection->getPoint(old_highlighted_id)) {
+                renderOrUpdatePoint(*old_point);
+            }
+            if (auto new_point = _point_collection->getPoint(_highlighted_point_id)) {
+                renderOrUpdatePoint(*new_point);
+            }
+        }
+    }
+
     invalidateVis();
     invalidateIntersect();
     renderIntersections();

--- a/apps/VC3D/CWindow.cpp
+++ b/apps/VC3D/CWindow.cpp
@@ -1631,8 +1631,56 @@ void CWindow::onSegFilterChanged(int index)
     if (!fVpkg) {
         return;
     }
+
+    // Check if ANY filters are actually active
+    bool hasActiveFilters = chkFilterFocusPoints->isChecked() ||
+                           chkFilterUnreviewed->isChecked() ||
+                           chkFilterRevisit->isChecked() ||
+                           chkFilterNoExpansion->isChecked() ||
+                           chkFilterNoDefective->isChecked() ||
+                           chkFilterPartialReview->isChecked() ||
+                           chkFilterCurrentOnly->isChecked();
+
+    // Check if point set filter has any checked items
+    if (!hasActiveFilters && cmbPointSetFilter->count() > 0) {
+        for (int i = 0; i < cmbPointSetFilter->count(); ++i) {
+            if (cmbPointSetFilter->itemData(i, Qt::CheckStateRole) == Qt::Checked) {
+                hasActiveFilters = true;
+                break;
+            }
+        }
+    }
+
+    // If no filters are active, show everything and exit early
+    if (!hasActiveFilters) {
+        // Show all items
+        QTreeWidgetItemIterator it(treeWidgetSurfaces);
+        while (*it) {
+            (*it)->setHidden(false);
+            ++it;
+        }
+
+        // Add all surfaces to intersection set
+        std::set<std::string> all_intersects = {"segmentation"};
+        for (const auto& pair : _vol_qsurfs) {
+            all_intersects.insert(pair.first);
+        }
+
+        // Apply to viewers
+        for (auto &viewer : _viewers) {
+            if (viewer->surfName() != "segmentation") {
+                viewer->setIntersects(all_intersects);
+            }
+        }
+
+        UpdateVolpkgLabel(0);
+        return;
+    }
+
     std::set<std::string> dbg_intersects = {"segmentation"};
-    
+    POI *poi = _surf_col->poi("focus");
+    int filterCounter = 0;
+
     // Check if "Current Segment Only" is checked
     bool currentOnly = chkFilterCurrentOnly->isChecked();
 
@@ -1641,304 +1689,137 @@ void CWindow::onSegFilterChanged(int index)
         if (!_surfID.empty() && _vol_qsurfs.count(_surfID)) {
             dbg_intersects.insert(_surfID);
         }
-
-        // Still need to update the tree visibility based on other filters
-        POI *poi = _surf_col->poi("focus");
-        int filterCounter = 0;
-
-        QTreeWidgetItemIterator it(treeWidgetSurfaces);
-        while (*it) {
-            std::string id = (*it)->data(SURFACE_ID_COLUMN, Qt::UserRole).toString().toStdString();
-
-            bool show = true;
-            if (!_vol_qsurfs.count(id)) {
-                show = true;
-            } else {
-                // Apply all filters except intersection display
-                bool hasActiveFilters = chkFilterFocusPoints->isChecked() ||
-                                      (cmbPointSetFilter->currentIndex() != -1) ||
-                                       chkFilterUnreviewed->isChecked() ||
-                                       chkFilterRevisit->isChecked() ||
-                                       chkFilterNoExpansion->isChecked() ||
-                                       chkFilterNoDefective->isChecked() ||
-                                       chkFilterPartialReview->isChecked();
-
-                if (!hasActiveFilters) {
-                    show = true;
-                } else {
-                    // Start with show = true and apply filters as AND conditions
-                    show = true;
-
-                    // Filter by focus points
-                    if (chkFilterFocusPoints->isChecked() && poi) {
-                        show = show && contains(*_vol_qsurfs[id], poi->p);
-                    }
-
-                    // Filter by point sets
-                    if (cmbPointSetFilter->currentIndex() != -1) {
-                        bool any_checked = false;
-                        for (int i = 0; i < cmbPointSetFilter->count(); ++i) {
-                            if (cmbPointSetFilter->itemData(i, Qt::CheckStateRole) == Qt::Checked) {
-                                any_checked = true;
-                                break;
-                            }
-                        }
-
-                        if (any_checked) {
-                            bool match = false;
-                            bool all_match = true;
-                            for (int i = 0; i < cmbPointSetFilter->count(); ++i) {
-                                if (cmbPointSetFilter->itemData(i, Qt::CheckStateRole) == Qt::Checked) {
-                                    std::vector<cv::Vec3f> points;
-                                    auto collection = _point_collection->getPoints(cmbPointSetFilter->itemText(i).toStdString());
-                                    points.reserve(collection.size());
-                                    for (const auto& p : collection) {
-                                        points.push_back(p.p);
-                                    }
-                                    if (all_match && !contains(*_vol_qsurfs[id], points))
-                                        all_match = false;
-                                    if (!match && contains_any(*_vol_qsurfs[id], points))
-                                        match = true;
-                                }
-                            }
-                            if (cmbPointSetFilterMode->currentIndex() == 0) { // Any (OR)
-                                show = show && match;
-                            } else { // All (AND)
-                                show = show && all_match;
-                            }
-                        }
-                    }
-
-                    // Filter by unreviewed
-                    if (chkFilterUnreviewed->isChecked()) {
-                        auto* surface = _vol_qsurfs[id]->surface();
-                        if (surface && surface->meta) {
-                            auto tags = surface->meta->value("tags", nlohmann::json::object_t());
-                            show = show && !tags.count("reviewed");
-                        } else {
-                            // If no metadata, consider it unreviewed
-                            show = show && true;
-                        }
-                    }
-
-                    // Filter by revisit
-                    if (chkFilterRevisit->isChecked()) {
-                        auto* surface = _vol_qsurfs[id]->surface();
-                        if (surface && surface->meta) {
-                            auto tags = surface->meta->value("tags", nlohmann::json::object_t());
-                            show = show && (tags.count("revisit") > 0);
-                        } else {
-                            // If no metadata, don't show for revisit filter
-                            show = show && false;
-                        }
-                    }
-
-                    // Filter out expansion
-                    if (chkFilterNoExpansion->isChecked()) {
-                        auto* surface = _vol_qsurfs[id]->surface();
-                        if (surface && surface->meta) {
-                            if (surface->meta->contains("vc_gsfs_mode")) {
-                                std::string mode = surface->meta->value("vc_gsfs_mode", "");
-                                show = show && (mode != "expansion");
-                            } else {
-                                // If the key doesn't exist, show the surface
-                                show = show && true;
-                            }
-                        } else {
-                            // If no metadata, show the surface
-                            show = show && true;
-                        }
-                    }
-
-                    // Filter out defective
-                    if (chkFilterNoDefective->isChecked()) {
-                        auto* surface = _vol_qsurfs[id]->surface();
-                        if (surface && surface->meta) {
-                            auto tags = surface->meta->value("tags", nlohmann::json::object_t());
-                            show = show && !tags.count("defective");
-                        } else {
-                            // If no metadata, consider it not defective (show it)
-                            show = show && true;
-                        }
-                    }
-
-                    // Filter out partial review
-                    if (chkFilterPartialReview->isChecked()) {
-                        auto* surface = _vol_qsurfs[id]->surface();
-                        if (surface && surface->meta) {
-                            auto tags = surface->meta->value("tags", nlohmann::json::object_t());
-                            show = show && !tags.count("partial_review");
-                        } else {
-                            // If no metadata, consider it not partially reviewed (show it)
-                            show = show && true;
-                        }
-                    }
-                }
-            }
-
-            (*it)->setHidden(!show);
-
-            if (!show) {
-                filterCounter++;
-            }
-
-            ++it;
-        }
-
-        UpdateVolpkgLabel(filterCounter);
-    } else {
-        // Original logic - process all segments with filters
-        POI *poi = _surf_col->poi("focus");
-        int filterCounter = 0;
-
-        // Check if any filters are active
-        bool hasActiveFilters = chkFilterFocusPoints->isChecked() ||
-                              (cmbPointSetFilter->currentIndex() != -1) ||
-                               chkFilterUnreviewed->isChecked() ||
-                               chkFilterRevisit->isChecked() ||
-                               chkFilterNoExpansion->isChecked() ||
-                               chkFilterNoDefective->isChecked() ||
-                               chkFilterPartialReview->isChecked();
-
-        QTreeWidgetItemIterator it(treeWidgetSurfaces);
-        while (*it) {
-            std::string id = (*it)->data(SURFACE_ID_COLUMN, Qt::UserRole).toString().toStdString();
-
-            bool show = true;
-            if (!_vol_qsurfs.count(id)) {
-                show = true;
-            } else if (!hasActiveFilters) {
-                // If no filters are active, show all
-                show = true;
-            } else {
-                // Start with show = true and apply filters as AND conditions
-                show = true;
-
-                // Filter by focus points
-                if (chkFilterFocusPoints->isChecked() && poi) {
-                    show = show && contains(*_vol_qsurfs[id], poi->p);
-                }
-
-                // Filter by point sets
-                if (cmbPointSetFilter->currentIndex() != -1) {
-                    bool any_checked = false;
-                    for (int i = 0; i < cmbPointSetFilter->count(); ++i) {
-                        if (cmbPointSetFilter->itemData(i, Qt::CheckStateRole) == Qt::Checked) {
-                            any_checked = true;
-                            break;
-                        }
-                    }
-
-                    if (any_checked) {
-                        bool match = false;
-                        bool all_match = true;
-                        for (int i = 0; i < cmbPointSetFilter->count(); ++i) {
-                            if (cmbPointSetFilter->itemData(i, Qt::CheckStateRole) == Qt::Checked) {
-                                std::vector<cv::Vec3f> points;
-                                auto collection = _point_collection->getPoints(cmbPointSetFilter->itemText(i).toStdString());
-                                points.reserve(collection.size());
-                                for (const auto& p : collection) {
-                                    points.push_back(p.p);
-                                }
-                                if (all_match && !contains(*_vol_qsurfs[id], points))
-                                    all_match = false;
-                                if (!match && contains_any(*_vol_qsurfs[id], points))
-                                    match = true;
-                            }
-                        }
-                        if (cmbPointSetFilterMode->currentIndex() == 0) { // Any (OR)
-                            show = show && match;
-                        } else { // All (AND)
-                            show = show && all_match;
-                        }
-                    }
-                }
-
-                // Filter by unreviewed
-                if (chkFilterUnreviewed->isChecked()) {
-                    auto* surface = _vol_qsurfs[id]->surface();
-                    if (surface && surface->meta) {
-                        auto tags = surface->meta->value("tags", nlohmann::json::object_t());
-                        show = show && !tags.count("reviewed");
-                    } else {
-                        // If no metadata, consider it unreviewed
-                        show = show && true;
-                    }
-                }
-
-                // Filter by revisit
-                if (chkFilterRevisit->isChecked()) {
-                    auto* surface = _vol_qsurfs[id]->surface();
-                    if (surface && surface->meta) {
-                        auto tags = surface->meta->value("tags", nlohmann::json::object_t());
-                        show = show && (tags.count("revisit") > 0);
-                    } else {
-                        // If no metadata, don't show for revisit filter
-                        show = show && false;
-                    }
-                }
-
-                // Filter out expansion
-                if (chkFilterNoExpansion->isChecked()) {
-                    auto* surface = _vol_qsurfs[id]->surface();
-                    if (surface && surface->meta) {
-                        if (surface->meta->contains("vc_gsfs_mode")) {
-                            std::string mode = surface->meta->value("vc_gsfs_mode", "");
-                            show = show && (mode != "expansion");
-                        } else {
-                            // If the key doesn't exist, show the surface
-                            show = show && true;
-                        }
-                    } else {
-                        // If no metadata, show the surface
-                        show = show && true;
-                    }
-                }
-
-                // Filter out defective
-                if (chkFilterNoDefective->isChecked()) {
-                    auto* surface = _vol_qsurfs[id]->surface();
-                    if (surface && surface->meta) {
-                        auto tags = surface->meta->value("tags", nlohmann::json::object_t());
-                        show = show && !tags.count("defective");
-                    } else {
-                        // If no metadata, consider it not defective (show it)
-                        show = show && true;
-                    }
-                }
-
-                // Filter out partial review
-                if (chkFilterPartialReview->isChecked()) {
-                    auto* surface = _vol_qsurfs[id]->surface();
-                    if (surface && surface->meta) {
-                        auto tags = surface->meta->value("tags", nlohmann::json::object_t());
-                        show = show && !tags.count("partial_review");
-                    } else {
-                        // If no metadata, consider it not partially reviewed (show it)
-                        show = show && true;
-                    }
-                }
-            }
-
-            (*it)->setHidden(!show);
-
-            if(show) {
-                if (_vol_qsurfs.count(id))
-                    dbg_intersects.insert(id);
-            } else {
-                filterCounter++;
-            }
-
-            ++it;
-        }
-
-        UpdateVolpkgLabel(filterCounter);
     }
 
+    QTreeWidgetItemIterator it(treeWidgetSurfaces);
+    while (*it) {
+        std::string id = (*it)->data(SURFACE_ID_COLUMN, Qt::UserRole).toString().toStdString();
+
+        bool show = true;
+        if (!_vol_qsurfs.count(id)) {
+            show = true;
+        } else {
+            // Start with show = true and apply filters as AND conditions
+            show = true;
+
+            // Filter by focus points
+            if (chkFilterFocusPoints->isChecked() && poi) {
+                show = show && contains(*_vol_qsurfs[id], poi->p);
+            }
+
+            // Filter by point sets
+            bool any_checked = false;
+            for (int i = 0; i < cmbPointSetFilter->count(); ++i) {
+                if (cmbPointSetFilter->itemData(i, Qt::CheckStateRole) == Qt::Checked) {
+                    any_checked = true;
+                    break;
+                }
+            }
+
+            if (any_checked) {
+                bool match = false;
+                bool all_match = true;
+                for (int i = 0; i < cmbPointSetFilter->count(); ++i) {
+                    if (cmbPointSetFilter->itemData(i, Qt::CheckStateRole) == Qt::Checked) {
+                        std::vector<cv::Vec3f> points;
+                        auto collection = _point_collection->getPoints(cmbPointSetFilter->itemText(i).toStdString());
+                        points.reserve(collection.size());
+                        for (const auto& p : collection) {
+                            points.push_back(p.p);
+                        }
+                        if (all_match && !contains(*_vol_qsurfs[id], points))
+                            all_match = false;
+                        if (!match && contains_any(*_vol_qsurfs[id], points))
+                            match = true;
+                    }
+                }
+                if (cmbPointSetFilterMode->currentIndex() == 0) { // Any (OR)
+                    show = show && match;
+                } else { // All (AND)
+                    show = show && all_match;
+                }
+            }
+
+            // Filter by unreviewed
+            if (chkFilterUnreviewed->isChecked()) {
+                auto* surface = _vol_qsurfs[id]->surface();
+                if (surface && surface->meta) {
+                    auto tags = surface->meta->value("tags", nlohmann::json::object_t());
+                    show = show && !tags.count("reviewed");
+                } else {
+                    show = show && true;
+                }
+            }
+
+            // Filter by revisit
+            if (chkFilterRevisit->isChecked()) {
+                auto* surface = _vol_qsurfs[id]->surface();
+                if (surface && surface->meta) {
+                    auto tags = surface->meta->value("tags", nlohmann::json::object_t());
+                    show = show && (tags.count("revisit") > 0);
+                } else {
+                    show = show && false;
+                }
+            }
+
+            // Filter out expansion
+            if (chkFilterNoExpansion->isChecked()) {
+                auto* surface = _vol_qsurfs[id]->surface();
+                if (surface && surface->meta) {
+                    if (surface->meta->contains("vc_gsfs_mode")) {
+                        std::string mode = surface->meta->value("vc_gsfs_mode", "");
+                        show = show && (mode != "expansion");
+                    } else {
+                        show = show && true;
+                    }
+                } else {
+                    show = show && true;
+                }
+            }
+
+            // Filter out defective
+            if (chkFilterNoDefective->isChecked()) {
+                auto* surface = _vol_qsurfs[id]->surface();
+                if (surface && surface->meta) {
+                    auto tags = surface->meta->value("tags", nlohmann::json::object_t());
+                    show = show && !tags.count("defective");
+                } else {
+                    show = show && true;
+                }
+            }
+
+            // Filter out partial review
+            if (chkFilterPartialReview->isChecked()) {
+                auto* surface = _vol_qsurfs[id]->surface();
+                if (surface && surface->meta) {
+                    auto tags = surface->meta->value("tags", nlohmann::json::object_t());
+                    show = show && !tags.count("partial_review");
+                } else {
+                    show = show && true;
+                }
+            }
+        }
+
+        (*it)->setHidden(!show);
+
+        if (show && !currentOnly) {
+            if (_vol_qsurfs.count(id))
+                dbg_intersects.insert(id);
+        } else if (!show) {
+            filterCounter++;
+        }
+
+        ++it;
+    }
+
+    UpdateVolpkgLabel(filterCounter);
+
     // Apply the intersection set to all non-segmentation viewers
-    for (auto &viewer : _viewers)
-        if (viewer->surfName() != "segmentation")
+    for (auto &viewer : _viewers) {
+        if (viewer->surfName() != "segmentation") {
             viewer->setIntersects(dbg_intersects);
+        }
+    }
 }
 
 

--- a/apps/VC3D/CWindow.cpp
+++ b/apps/VC3D/CWindow.cpp
@@ -892,7 +892,7 @@ void CWindow::UpdateVolpkgLabel(int filterCounter)
     if (!fVpkg) {
         return;
     }
-    QString label = tr("%1 (%2 Surfaces | %3 filtered)").arg(QString::fromStdString(fVpkg->name())).arg(fVpkg->segmentationIDs().size()).arg(filterCounter);
+    QString label = tr("%1").arg(QString::fromStdString(fVpkg->name()));
     ui.lblVpkgName->setText(label);
 }
 


### PR DESCRIPTION
the setpoi stuff gets called every scroll tick, which is bad because it's expensive, so we need to defer that. This also fixes z slice rendering.

I did break z slice navigation in the segmentation view, so it's not quite ready for merge, but will fix