### PR TITLE
delete old hardcoded awscli x86 install from s3 docker

### DIFF
--- a/ubuntu-24.04-noble-s3.Dockerfile
+++ b/ubuntu-24.04-noble-s3.Dockerfile
@@ -31,10 +31,6 @@ RUN rm -r /src
 
 RUN apt-get -y install curl wget unzip
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-RUN unzip awscliv2.zip
-RUN ./aws/install
-
 RUN apt-get -y install fuse jq
 RUN wget https://github.com/kahing/goofys/releases/latest/download/goofys -O /usr/local/bin/goofys
 RUN chmod +x /usr/local/bin/goofys


### PR DESCRIPTION
I didn't notice this line in the s3 noble docker. Our docker images may run on either x86 64 or arm64 so we need to detect that in the docker script