### PR TITLE
SLIM Flattening & Rendering

### DIFF
--- a/apps/VC3D/CWindow.cpp
+++ b/apps/VC3D/CWindow.cpp
@@ -1958,7 +1958,13 @@ void CWindow::onSurfaceContextMenuRequested(const QPoint& pos)
     connect(renderAction, &QAction::triggered, [this, segmentId]() {
         onRenderSegment(segmentId);
     });
-    
+
+    // SLIM-flatten and render (calls slot implemented in CWindowContextMenu.cpp)
+    QAction* slimFlattenAction = new QAction(tr("SLIM-flatten and render"), this);
+    connect(slimFlattenAction, &QAction::triggered, [this, segmentId]() {
+        onSlimFlattenAndRender(segmentId);
+    });
+
     // Grow segment from segment action
     QAction* growSegmentAction = new QAction(tr("Run Trace"), this);
     connect(growSegmentAction, &QAction::triggered, [this, segmentId]() {
@@ -1979,30 +1985,23 @@ void CWindow::onSurfaceContextMenuRequested(const QPoint& pos)
     
     // Seed submenu with options
     QMenu* seedMenu = new QMenu(tr("Run Seed"), &contextMenu);
-    
-    // Seed with Seed.json action
     QAction* seedWithSeedAction = new QAction(tr("Seed from Focus Point"), seedMenu);
     connect(seedWithSeedAction, &QAction::triggered, [this, segmentId]() {
         onGrowSeeds(segmentId, false, false);
     });
-    
-    // Random Seed with Seed.json action
     QAction* seedWithRandomAction = new QAction(tr("Random Seed"), seedMenu);
     connect(seedWithRandomAction, &QAction::triggered, [this, segmentId]() {
         onGrowSeeds(segmentId, false, true);
     });
-    
-    // Seed with Expand.json action
     QAction* seedWithExpandAction = new QAction(tr("Expand Seed"), seedMenu);
     connect(seedWithExpandAction, &QAction::triggered, [this, segmentId]() {
         onGrowSeeds(segmentId, true, false);
     });
-    
     seedMenu->addAction(seedWithSeedAction);
     seedMenu->addAction(seedWithRandomAction);
     seedMenu->addAction(seedWithExpandAction);
     
-    // Add all actions to the context menu
+    // Build menu
     contextMenu.addAction(copyPathAction);
     contextMenu.addSeparator();
     contextMenu.addMenu(seedMenu);
@@ -2010,12 +2009,11 @@ void CWindow::onSurfaceContextMenuRequested(const QPoint& pos)
     contextMenu.addAction(addOverlapAction);
     contextMenu.addSeparator();
     contextMenu.addAction(renderAction);
-    contextMenu.addSeparator();
     contextMenu.addAction(convertToObjAction);
+    contextMenu.addAction(slimFlattenAction);
     contextMenu.addSeparator();
     contextMenu.addAction(deleteAction);
     
-    // show the context menu at the position of the right-click
     contextMenu.exec(treeWidgetSurfaces->mapToGlobal(pos));
 }
 

--- a/apps/VC3D/CWindow.hpp
+++ b/apps/VC3D/CWindow.hpp
@@ -78,6 +78,7 @@ public slots:
     void onGrowSegmentFromSegment(const SurfaceID& segmentId);
     void onAddOverlap(const SurfaceID& segmentId);
     void onConvertToObj(const SurfaceID& segmentId);
+    void onSlimFlattenAndRender(const SurfaceID& segmentId);
     void onGrowSeeds(const SurfaceID& segmentId, bool isExpand, bool isRandomSeed = false);
     void onToggleConsoleOutput();
     void onDeleteSegments(const std::vector<SurfaceID>& segmentIds);

--- a/apps/VC3D/CWindowContextMenu.cpp
+++ b/apps/VC3D/CWindowContextMenu.cpp
@@ -3,6 +3,11 @@
 
 #include <QSettings>
 #include <QMessageBox>
+#include <QProcess>
+#include <QDir>
+#include <QFileInfo>
+#include <QCoreApplication>
+#include <QDateTime>
 
 #include "vc/core/types/VolumePkg.hpp"
 #include "vc/core/util/Surface.hpp"
@@ -11,34 +16,92 @@ namespace vc = volcart;
 using namespace ChaoVis;
 namespace fs = std::filesystem;
 
+// --------- local helpers for running external tools -------------------------
+static bool runProcessBlocking(const QString& program,
+                               const QStringList& args,
+                               const QString& workDir,
+                               QString* out=nullptr,
+                               QString* err=nullptr)
+{
+    QProcess p;
+    if (!workDir.isEmpty()) p.setWorkingDirectory(workDir);
+    p.setProcessChannelMode(QProcess::SeparateChannels);
+    p.start(program, args);
+    if (!p.waitForStarted()) { if (err) *err = QObject::tr("Failed to start %1").arg(program); return false; }
+    if (!p.waitForFinished(-1)) { if (err) *err = QObject::tr("Timeout running %1").arg(program); return false; }
+    if (out) *out = QString::fromLocal8Bit(p.readAllStandardOutput());
+    if (err) *err = QString::fromLocal8Bit(p.readAllStandardError());
+    return (p.exitStatus()==QProcess::NormalExit && p.exitCode()==0);
+}
+
+static QString resolvePythonPath()
+{
+    QSettings s("VC.ini", QSettings::IniFormat);
+    const QString ini = s.value("python/path").toString();
+    if (!ini.isEmpty() && QFileInfo::exists(ini)) return ini;
+
+    const QString env = QString::fromLocal8Bit(qgetenv("VC_PYTHON"));
+    if (!env.isEmpty() && QFileInfo::exists(env)) return env;
+
+    // Prefer micromamba env you mentioned
+    if (QFileInfo::exists("/opt/micromamba/envs/py310/bin/python"))
+        return "/opt/micromamba/envs/py310/bin/python";
+
+    // Reasonable fallbacks
+    if (QFileInfo::exists("/opt/venv/bin/python3"))  return "/opt/venv/bin/python3";
+    if (QFileInfo::exists("/usr/local/bin/python3")) return "/usr/local/bin/python3";
+    if (QFileInfo::exists("/usr/bin/python3"))       return "/usr/bin/python3";
+    return "python3";
+}
+
+static QString resolveFlatboiScript()
+{
+    QSettings s("VC.ini", QSettings::IniFormat);
+    const QString ini = s.value("scripts/flatboi_path").toString();
+    if (!ini.isEmpty()) return ini;
+
+    const QString envDir = QString::fromLocal8Bit(qgetenv("VC_SCRIPTS_DIR"));
+    if (!envDir.isEmpty()) return QDir(envDir).filePath("flatboi.py");
+
+    // Default to the repo path you requested
+    if (QFileInfo::exists("/src/scripts/flatboi.py"))
+        return "/src/scripts/flatboi.py";
+
+    // Last resort: relative to binary
+    QDir bin(QCoreApplication::applicationDirPath());
+    return QDir(bin.filePath("../scripts")).filePath("flatboi.py");
+}
+// ---------------------------------------------------------------------------
+
+
 void CWindow::onRenderSegment(const SurfaceID& segmentId)
 {
     if (currentVolume == nullptr || !_vol_qsurfs.count(segmentId)) {
         QMessageBox::warning(this, tr("Error"), tr("Cannot render segment: No volume or invalid segment selected"));
         return;
     }
-    
+
     QSettings settings("VC.ini", QSettings::IniFormat);
-    
+
     QString outputFormat = settings.value("rendering/output_path_format", "%s/layers/%02d.tif").toString();
     float scale = settings.value("rendering/scale", 1.0f).toFloat();
     int resolution = settings.value("rendering/resolution", 0).toInt();
     int layers = settings.value("rendering/layers", 31).toInt();
-    
+
     QString segmentPath = QString::fromStdString(_vol_qsurfs[segmentId]->path.string());
     QString segmentOutDir = QString::fromStdString(_vol_qsurfs[segmentId]->path.string());
     QString outputPattern = outputFormat.replace("%s", segmentOutDir);
-    
+
     // Initialize command line tool runner if needed
     if (!_cmdRunner) {
         _cmdRunner = new CommandLineToolRunner(statusBar(), this, this);
-        connect(_cmdRunner, &CommandLineToolRunner::toolStarted, 
-                [this](CommandLineToolRunner::Tool tool, const QString& message) {
+        connect(_cmdRunner, &CommandLineToolRunner::toolStarted,
+                [this](CommandLineToolRunner::Tool /*tool*/, const QString& message) {
                     statusBar()->showMessage(message, 0);
                 });
         connect(_cmdRunner, &CommandLineToolRunner::toolFinished,
-                [this](CommandLineToolRunner::Tool tool, bool success, const QString& message,
-                       const QString& outputPath, bool copyToClipboard) {
+                [this](CommandLineToolRunner::Tool /*tool*/, bool success, const QString& message,
+                       const QString& /*outputPath*/, bool copyToClipboard) {
                     if (success) {
                         QString displayMsg = message;
                         if (copyToClipboard) {
@@ -52,22 +115,131 @@ void CWindow::onRenderSegment(const SurfaceID& segmentId)
                     }
                 });
     }
-    
+
     // Check if a tool is already running
     if (_cmdRunner->isRunning()) {
         QMessageBox::warning(this, tr("Warning"), tr("A command line tool is already running."));
         return;
     }
-    
+
     // Set up parameters and execute the render tool
     _cmdRunner->setSegmentPath(segmentPath);
     _cmdRunner->setOutputPattern(outputPattern);
     _cmdRunner->setRenderParams(scale, resolution, layers);
-    
+
     _cmdRunner->execute(CommandLineToolRunner::Tool::RenderTifXYZ);
-    
+
     statusBar()->showMessage(tr("Rendering segment: %1").arg(QString::fromStdString(segmentId)), 5000);
 }
+
+void CWindow::onSlimFlattenAndRender(const SurfaceID& segmentId)
+{
+    if (currentVolume == nullptr || !_vol_qsurfs.count(segmentId)) {
+        QMessageBox::warning(this, tr("Error"), tr("Cannot SLIM-flatten: No volume or invalid segment selected"));
+        return;
+    }
+    if (_cmdRunner && _cmdRunner->isRunning()) {
+        QMessageBox::warning(this, tr("Warning"), tr("A command line tool is already running."));
+        return;
+    }
+
+    // Paths
+    const fs::path segDirFs = _vol_qsurfs[segmentId]->path;           // tifxyz folder
+    const QString  segDir   = QString::fromStdString(segDirFs.string());
+    const QString  objPath  = QDir(segDir).filePath(QString::fromStdString(segmentId) + ".obj");
+    const QString  flatObj  = QDir(segDir).filePath(QString::fromStdString(segmentId) + "_flatboi.obj");
+    QString        outTifxyz= segDir + "_flatboi";
+
+    // If the output dir already exists, offer to delete it (vc_obj2tifxyz requires a non-existent target)
+    if (QFileInfo::exists(outTifxyz)) {
+        const auto ans = QMessageBox::question(
+            this, tr("Output Exists"),
+            tr("The output directory already exists:\n%1\n\nDelete it and recreate?").arg(outTifxyz),
+            QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+        if (ans == QMessageBox::No) {
+            statusBar()->showMessage(tr("SLIM-flatten cancelled by user (existing output)."), 5000);
+            return;
+        }
+        QDir dir(outTifxyz);
+        if (!dir.removeRecursively()) {
+            QMessageBox::critical(this, tr("Error"),
+                                  tr("Failed to remove existing output directory:\n%1").arg(outTifxyz));
+            return;
+        }
+    }
+
+    // 1) tifxyz -> obj
+    statusBar()->showMessage(tr("Converting TIFXYZ to OBJ…"), 0);
+    {
+        QString err;
+        if (!runProcessBlocking("vc_tifxyz2obj", QStringList() << segDir << objPath, segDir, nullptr, &err)) {
+            QMessageBox::critical(this, tr("Error"), tr("vc_tifxyz2obj failed.\n\n%1").arg(err));
+            statusBar()->showMessage(tr("SLIM-flatten failed"), 5000);
+            return;
+        }
+    }
+
+    // 2) SLIM via python: python /src/scripts/flatboi.py <obj> 60
+    statusBar()->showMessage(tr("Running SLIM (flatboi.py)…"), 0);
+    {
+        const QString py = resolvePythonPath();
+        const QString script = resolveFlatboiScript();
+        if (!QFileInfo::exists(script)) {
+            QMessageBox::critical(this, tr("Error"), tr("flatboi.py not found at:\n%1").arg(script));
+            statusBar()->showMessage(tr("SLIM-flatten failed"), 5000);
+            return;
+        }
+        QString err;
+        if (!runProcessBlocking(py, QStringList() << script << objPath << "60", segDir, nullptr, &err)) {
+            QMessageBox::critical(this, tr("Error"), tr("flatboi.py failed.\n\n%1").arg(err));
+            statusBar()->showMessage(tr("SLIM-flatten failed"), 5000);
+            return;
+        }
+        if (!QFileInfo::exists(flatObj)) {
+            // flatboi writes <basename>_flatboi.obj next to the input .obj
+            QMessageBox::critical(this, tr("Error"),
+                                  tr("Flattened OBJ was not created:\n%1").arg(flatObj));
+            statusBar()->showMessage(tr("SLIM-flatten failed"), 5000);
+            return;
+        }
+    }
+
+    // 3) flattened obj -> tifxyz  (IMPORTANT: do NOT pre-create the directory)
+    statusBar()->showMessage(tr("Converting flattened OBJ back to TIFXYZ…"), 0);
+    {
+        QString err;
+        if (!runProcessBlocking("vc_obj2tifxyz", QStringList() << flatObj << outTifxyz, segDir, nullptr, &err)) {
+            QMessageBox::critical(this, tr("Error"), tr("vc_obj2tifxyz failed.\n\n%1").arg(err));
+            statusBar()->showMessage(tr("SLIM-flatten failed"), 5000);
+            return;
+        }
+    }
+
+    // 4) render the *_flatboi folder
+    if (!initializeCommandLineRunner()) {
+        QMessageBox::critical(this, tr("Error"), tr("Failed to initialize command runner."));
+        return;
+    }
+    if (_cmdRunner->isRunning()) {
+        QMessageBox::warning(this, tr("Warning"), tr("A command line tool is already running."));
+        return;
+    }
+    {
+        QSettings settings("VC.ini", QSettings::IniFormat);
+        QString outputFormat = settings.value("rendering/output_path_format", "%s/layers/%02d.tif").toString();
+        float scale = settings.value("rendering/scale", 1.0f).toFloat();
+        int resolution = settings.value("rendering/resolution", 0).toInt();
+        int layers = settings.value("rendering/layers", 31).toInt();
+        const QString outPattern = outputFormat.replace("%s", outTifxyz);
+
+        _cmdRunner->setSegmentPath(outTifxyz);
+        _cmdRunner->setOutputPattern(outPattern);
+        _cmdRunner->setRenderParams(scale, resolution, layers);
+        _cmdRunner->execute(CommandLineToolRunner::Tool::RenderTifXYZ);
+        statusBar()->showMessage(tr("Rendering flattened segment…"), 0);
+    }
+}
+
 
 void CWindow::onGrowSegmentFromSegment(const SurfaceID& segmentId)
 {
@@ -75,29 +247,29 @@ void CWindow::onGrowSegmentFromSegment(const SurfaceID& segmentId)
         QMessageBox::warning(this, tr("Error"), tr("Cannot grow segment: No volume or invalid segment selected"));
         return;
     }
-    
+
     // Initialize command line tool runner if needed
     if (!initializeCommandLineRunner()) {
         return;
     }
-    
+
     // Check if a tool is already running
     if (_cmdRunner->isRunning()) {
         QMessageBox::warning(this, tr("Warning"), tr("A command line tool is already running."));
         return;
     }
-    
+
     // Get paths
     QString srcSegment = QString::fromStdString(_vol_qsurfs[segmentId]->path.string());
-    
+
     // Get the volpkg path and create traces directory if it doesn't exist
     fs::path volpkgPath = fs::path(fVpkgPath.toStdString());
     fs::path tracesDir = volpkgPath / "traces";
     fs::path jsonParamsPath = volpkgPath / "trace_params.json";
     fs::path pathsDir = volpkgPath / "paths";
-    
+
     statusBar()->showMessage(tr("Preparing to run grow_seg_from_segment..."), 2000);
-    
+
     // Create traces directory if it doesn't exist
     if (!fs::exists(tracesDir)) {
         try {
@@ -107,13 +279,13 @@ void CWindow::onGrowSegmentFromSegment(const SurfaceID& segmentId)
             return;
         }
     }
-    
+
     // Check if trace_params.json exists
     if (!fs::exists(jsonParamsPath)) {
         QMessageBox::warning(this, tr("Error"), tr("trace_params.json not found in the volpkg"));
         return;
     }
-    
+
     // Set up parameters and execute the tool
     _cmdRunner->setTraceParams(
         QString(),  // Volume path will be set automatically in execute()
@@ -122,12 +294,12 @@ void CWindow::onGrowSegmentFromSegment(const SurfaceID& segmentId)
         QString::fromStdString(jsonParamsPath.string()),
         srcSegment
     );
-    
+
     // Show console before executing to see any debug output
     _cmdRunner->showConsoleOutput();
-    
+
     _cmdRunner->execute(CommandLineToolRunner::Tool::GrowSegFromSegment);
-    
+
     statusBar()->showMessage(tr("Growing segment from: %1").arg(QString::fromStdString(segmentId)), 5000);
 }
 
@@ -137,31 +309,31 @@ void CWindow::onAddOverlap(const SurfaceID& segmentId)
         QMessageBox::warning(this, tr("Error"), tr("Cannot add overlap: No volume or invalid segment selected"));
         return;
     }
-    
+
     // Initialize command line tool runner if needed
     if (!initializeCommandLineRunner()) {
         return;
     }
-    
+
     // Check if a tool is already running
     if (_cmdRunner->isRunning()) {
         QMessageBox::warning(this, tr("Warning"), tr("A command line tool is already running."));
         return;
     }
-    
+
     // Get paths
     fs::path volpkgPath = fs::path(fVpkgPath.toStdString());
     fs::path pathsDir = volpkgPath / "paths";
     QString tifxyzPath = QString::fromStdString(_vol_qsurfs[segmentId]->path.string());
-    
+
     // Set up parameters and execute the tool
     _cmdRunner->setAddOverlapParams(
         QString::fromStdString(pathsDir.string()),
         tifxyzPath
     );
-    
+
     _cmdRunner->execute(CommandLineToolRunner::Tool::SegAddOverlap);
-    
+
     statusBar()->showMessage(tr("Adding overlap for segment: %1").arg(QString::fromStdString(segmentId)), 5000);
 }
 
@@ -171,32 +343,32 @@ void CWindow::onConvertToObj(const SurfaceID& segmentId)
         QMessageBox::warning(this, tr("Error"), tr("Cannot convert to OBJ: No volume or invalid segment selected"));
         return;
     }
-    
+
     // Initialize command line tool runner if needed
     if (!initializeCommandLineRunner()) {
         return;
     }
-    
+
     // Check if a tool is already running
     if (_cmdRunner->isRunning()) {
         QMessageBox::warning(this, tr("Warning"), tr("A command line tool is already running."));
         return;
     }
-    
+
     // Get source tifxyz path (this is a directory containing the TIFXYZ files)
     fs::path tifxyzPath = _vol_qsurfs[segmentId]->path;
-    
+
     // Generate output OBJ path inside the TIFXYZ directory with segment ID as filename
     fs::path objPath = tifxyzPath / (segmentId + ".obj");
-    
+
     // Set up parameters and execute the tool
     _cmdRunner->setToObjParams(
         QString::fromStdString(tifxyzPath.string()),
         QString::fromStdString(objPath.string())
     );
-    
+
     _cmdRunner->execute(CommandLineToolRunner::Tool::tifxyz2obj);
-    
+
     statusBar()->showMessage(tr("Converting segment to OBJ: %1").arg(QString::fromStdString(segmentId)), 5000);
 }
 
@@ -206,38 +378,38 @@ void CWindow::onGrowSeeds(const SurfaceID& segmentId, bool isExpand, bool isRand
         QMessageBox::warning(this, tr("Error"), tr("Cannot grow seeds: No volume loaded"));
         return;
     }
-    
+
     // Initialize command line tool runner if needed
     if (!initializeCommandLineRunner()) {
         return;
     }
-    
+
     // Check if a tool is already running
     if (_cmdRunner->isRunning()) {
         QMessageBox::warning(this, tr("Warning"), tr("A command line tool is already running."));
         return;
     }
-    
+
     // Get paths
     fs::path volpkgPath = fs::path(fVpkgPath.toStdString());
     fs::path pathsDir = volpkgPath / "paths";
-    
+
     // Create traces directory if it doesn't exist
     if (!fs::exists(pathsDir)) {
         QMessageBox::warning(this, tr("Error"), tr("Paths directory not found in the volpkg"));
         return;
     }
-    
+
     // Get JSON parameters file
     QString jsonFileName = isExpand ? "expand.json" : "seed.json";
     fs::path jsonParamsPath = volpkgPath / jsonFileName.toStdString();
-    
+
     // Check if JSON file exists
     if (!fs::exists(jsonParamsPath)) {
         QMessageBox::warning(this, tr("Error"), tr("%1 not found in the volpkg").arg(jsonFileName));
         return;
     }
-    
+
     // Get current POI (focus point) for seed coordinates if needed
     int seedX = 0, seedY = 0, seedZ = 0;
     if (!isExpand && !isRandomSeed) {
@@ -250,7 +422,7 @@ void CWindow::onGrowSeeds(const SurfaceID& segmentId, bool isExpand, bool isRand
         seedY = static_cast<int>(poi->p[1]);
         seedZ = static_cast<int>(poi->p[2]);
     }
-    
+
     // Set up parameters and execute the tool
     _cmdRunner->setGrowParams(
         QString(),  // Volume path will be set automatically in execute()
@@ -262,10 +434,10 @@ void CWindow::onGrowSeeds(const SurfaceID& segmentId, bool isExpand, bool isRand
         isExpand,
         isRandomSeed
     );
-    
+
     _cmdRunner->execute(CommandLineToolRunner::Tool::GrowSegFromSeeds);
-    
-    QString modeDesc = isExpand ? "expand mode" : 
+
+    QString modeDesc = isExpand ? "expand mode" :
                       (isRandomSeed ? "random seed mode" : "seed mode");
     statusBar()->showMessage(tr("Growing segment using %1 in %2").arg(jsonFileName).arg(modeDesc), 5000);
 }
@@ -275,22 +447,22 @@ bool CWindow::initializeCommandLineRunner()
 {
     if (!_cmdRunner) {
         _cmdRunner = new CommandLineToolRunner(statusBar(), this, this);
-        
+
         // Read parallel processes and iteration count settings from INI file
         QSettings settings("VC.ini", QSettings::IniFormat);
         int parallelProcesses = settings.value("perf/parallel_processes", 8).toInt();
         int iterationCount = settings.value("perf/iteration_count", 1000).toInt();
-        
+
         // Apply the settings
         _cmdRunner->setParallelProcesses(parallelProcesses);
         _cmdRunner->setIterationCount(iterationCount);
-        
-        connect(_cmdRunner, &CommandLineToolRunner::toolStarted, 
-                [this](CommandLineToolRunner::Tool tool, const QString& message) {
+
+        connect(_cmdRunner, &CommandLineToolRunner::toolStarted,
+                [this](CommandLineToolRunner::Tool /*tool*/, const QString& message) {
                     statusBar()->showMessage(message, 0);
                 });
-        connect(_cmdRunner, &CommandLineToolRunner::toolFinished, 
-                [this](CommandLineToolRunner::Tool tool, bool success, const QString& message, 
+        connect(_cmdRunner, &CommandLineToolRunner::toolFinished,
+                [this](CommandLineToolRunner::Tool /*tool*/, bool success, const QString& message,
                        const QString& outputPath, bool copyToClipboard) {
                     if (success) {
                         QString displayMsg = message;
@@ -313,7 +485,7 @@ void CWindow::onDeleteSegments(const std::vector<SurfaceID>& segmentIds)
     if (segmentIds.empty()) {
         return;
     }
-    
+
     // Create confirmation message
     QString message;
     if (segmentIds.size() == 1) {
@@ -323,21 +495,21 @@ void CWindow::onDeleteSegments(const std::vector<SurfaceID>& segmentIds)
         message = tr("Are you sure you want to delete %1 segments?\n\nThis action cannot be undone.")
                     .arg(segmentIds.size());
     }
-    
+
     // Show confirmation dialog
     QMessageBox::StandardButton reply = QMessageBox::question(
         this, tr("Confirm Deletion"), message,
         QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
-    
+
     if (reply != QMessageBox::Yes) {
         return;
     }
-    
+
     // Delete each segment
     int successCount = 0;
     QStringList failedSegments;
     bool needsReload = false;
-    
+
     for (const auto& segmentId : segmentIds) {
         try {
             // Use the VolumePkg's removeSegmentation method
@@ -346,7 +518,7 @@ void CWindow::onDeleteSegments(const std::vector<SurfaceID>& segmentIds)
             needsReload = true;
         } catch (const fs::filesystem_error& e) {
             std::cerr << "Failed to delete segment " << segmentId << ": " << e.what() << std::endl;
-            
+
             // Check if it's a permission error
             if (e.code() == std::errc::permission_denied) {
                 failedSegments << QString::fromStdString(segmentId) + " (permission denied)";
@@ -358,34 +530,34 @@ void CWindow::onDeleteSegments(const std::vector<SurfaceID>& segmentIds)
             std::cerr << "Failed to delete segment " << segmentId << ": " << e.what() << std::endl;
         }
     }
-    
+
     // Only update UI if we successfully deleted something
     if (needsReload) {
         try {
             // Use incremental removal to update the UI for each successfully deleted segment
             for (const auto& segmentId : segmentIds) {
                 // Only remove from UI if it was successfully deleted from disk
-                if (std::find(failedSegments.begin(), failedSegments.end(), 
+                if (std::find(failedSegments.begin(), failedSegments.end(),
                             QString::fromStdString(segmentId)) == failedSegments.end() &&
-                    std::find(failedSegments.begin(), failedSegments.end(), 
+                    std::find(failedSegments.begin(), failedSegments.end(),
                             QString::fromStdString(segmentId) + " (permission denied)") == failedSegments.end() &&
-                    std::find(failedSegments.begin(), failedSegments.end(), 
+                    std::find(failedSegments.begin(), failedSegments.end(),
                             QString::fromStdString(segmentId) + " (filesystem error)") == failedSegments.end()) {
                     RemoveSingleSegmentation(segmentId);
                 }
             }
-            
+
             // Update the volpkg label and filters
             UpdateVolpkgLabel(0);
             onSegFilterChanged(0);
         } catch (const std::exception& e) {
             std::cerr << "Error updating UI after deletion: " << e.what() << std::endl;
-            QMessageBox::warning(this, tr("Warning"), 
+            QMessageBox::warning(this, tr("Warning"),
                                tr("Segments were deleted but there was an error refreshing the list. "
                                   "Please reload surfaces manually."));
         }
     }
-    
+
     // Show result message
     if (successCount == segmentIds.size()) {
         statusBar()->showMessage(tr("Successfully deleted %1 segment(s)").arg(successCount), 5000);

--- a/apps/src/vc_obj2tifxyz.cpp
+++ b/apps/src/vc_obj2tifxyz.cpp
@@ -1,5 +1,6 @@
 #include "vc/core/util/Surface.hpp"
 #include "vc/core/util/Slicing.hpp"
+#include <cctype>
 
 #include <iostream>
 #include <fstream>
@@ -25,6 +26,11 @@ struct Face {
     int vt[3]; // texture coordinate indices
 };
 
+// Helpers for flag parsing
+static bool starts_with(const std::string& s, const std::string& p) {
+    return s.size() >= p.size() && std::equal(p.begin(), p.end(), s.begin());
+}
+
 class ObjToTifxyzConverter {
 private:
     std::vector<Vertex> vertices;
@@ -34,8 +40,13 @@ private:
     cv::Vec2f uv_min, uv_max;
     cv::Vec2i grid_size;
     cv::Vec2f scale;
-    
+    // UV handling
+    bool uv_is_metric = true;  // if true, scale comes from UV spacing
+    float uv_to_obj   = 1.0f;   // OBJ units per 1 UV unit (used when uv_is_metric)
+
 public:
+    void setUVMetric(bool v) { uv_is_metric = v; }
+    void setUVToObj(float r) { uv_to_obj = r; }
     bool loadObj(const std::string& filename) {
         std::ifstream file(filename);
         if (!file.is_open()) {
@@ -100,7 +111,7 @@ public:
         return !vertices.empty() && !faces.empty() && !uvs.empty();
     }
     
-    void determineGridDimensions(float stretch_factor = 1000.0f) {
+    void determineGridDimensions(float stretch_factor = 1.0f) {
         // Find UV bounds from all UVs used in faces
         uv_min = cv::Vec2f(std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
         uv_max = cv::Vec2f(std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest());
@@ -120,45 +131,41 @@ public:
         std::cout << "UV bounds: [" << uv_min[0] << ", " << uv_min[1] << "] to [" 
                   << uv_max[0] << ", " << uv_max[1] << "]" << std::endl;
         
-        // Two-pass approach:
-        // Pass 1: Create preliminary grid to measure scale
+        // Build grid from UV range and stretch factor
         cv::Vec2f uv_range = uv_max - uv_min;
-        cv::Vec2i preliminary_grid_size;
-        preliminary_grid_size[0] = static_cast<int>(std::ceil(uv_range[0] * stretch_factor)) + 1;
-        preliminary_grid_size[1] = static_cast<int>(std::ceil(uv_range[1] * stretch_factor)) + 1;
-        
-        std::cout << "Creating preliminary grid: " << preliminary_grid_size[0] << " x " << preliminary_grid_size[1] << " to measure scale..." << std::endl;
-        
-        // Temporary scale for preliminary rasterization
-        cv::Vec2f temp_scale;
-        temp_scale[0] = uv_range[0] * stretch_factor / (preliminary_grid_size[0] - 1);
-        temp_scale[1] = uv_range[1] * stretch_factor / (preliminary_grid_size[1] - 1);
-        
-        // Create preliminary grid
-        cv::Mat_<cv::Vec3f> preliminary_points(preliminary_grid_size[1], preliminary_grid_size[0], cv::Vec3f(-1, -1, -1));
-        
-        // Rasterize with temporary scale
-        scale = temp_scale;
-        grid_size = preliminary_grid_size;
-        for (const auto& face : faces) {
-            rasterizeTriangle(preliminary_points, face);
+        grid_size[0] = std::max(2, static_cast<int>(std::ceil(uv_range[0] * stretch_factor)) + 1);
+        grid_size[1] = std::max(2, static_cast<int>(std::ceil(uv_range[1] * stretch_factor)) + 1);
+
+        if (uv_is_metric) {
+            // Directly derive scale (OBJ units per grid step) from UV spacing
+            // pixel size in UV units
+            const float du = (grid_size[0] > 1) ? uv_range[0] / float(grid_size[0] - 1) : 0.f;
+            const float dv = (grid_size[1] > 1) ? uv_range[1] / float(grid_size[1] - 1) : 0.f;
+            scale[0] = du * uv_to_obj; // OBJ units per pixel in U
+            scale[1] = dv * uv_to_obj; // OBJ units per pixel in V
+            std::cout << "UV-metric mode: grid " << grid_size[0] << " x " << grid_size[1]
+                      << "  scale(OBJ units): " << scale[0] << ", " << scale[1] << std::endl;
+        } else {
+            // Two-pass approach (pre-rasterize then measure in 3D)
+            std::cout << "Creating preliminary grid " << grid_size[0] << " x " << grid_size[1]
+                      << " to measure scale from 3D..." << std::endl;
+            cv::Mat_<cv::Vec3f> preliminary_points(
+                grid_size[1], grid_size[0], cv::Vec3f(-1, -1, -1));
+
+            for (const auto& face : faces) {
+                rasterizeTriangle(preliminary_points, face);
+            }
+            // This fills 'scale' in OBJ units
+            calculateScaleFromGrid(preliminary_points);
+
+            // Re-derive grid from measured physical spacing × stretch
+            const cv::Vec2f measured = scale;
+            grid_size[0] = std::max(2, static_cast<int>(std::round(measured[0] * stretch_factor)) + 1);
+            grid_size[1] = std::max(2, static_cast<int>(std::round(measured[1] * stretch_factor)) + 1);
+
+            std::cout << "Final grid: " << grid_size[0] << " x " << grid_size[1] << std::endl;
+            std::cout << "Scale(OBJ units): " << measured[0] << ", " << measured[1] << std::endl;
         }
-        
-        // Calculate actual scale from preliminary grid
-        calculateScaleFromGrid(preliminary_points);
-        cv::Vec2f measured_scale = scale;
-        
-        // Pass 2: Calculate final grid dimensions from measured scale
-        // The measured scale tells us the physical distance between adjacent grid points
-        // We multiply by stretch_factor to get the number of grid points needed
-        grid_size[0] = static_cast<int>(std::round(measured_scale[0] * stretch_factor)) + 1;
-        grid_size[1] = static_cast<int>(std::round(measured_scale[1] * stretch_factor)) + 1;
-        
-        std::cout << "Final grid dimensions: " << grid_size[0] << " x " << grid_size[1] << std::endl;
-        std::cout << "Scale factors: " << measured_scale[0] << ", " << measured_scale[1] << std::endl;
-        
-        // Set final scale
-        scale = measured_scale;
     }
     
     QuadSurface* createQuadSurface(float mesh_units = 1.0f) {
@@ -183,8 +190,18 @@ public:
         std::cout << "Valid grid points: " << valid_count << " / " << (grid_size[0] * grid_size[1]) 
                   << " (" << (100.0f * valid_count / (grid_size[0] * grid_size[1])) << "%)" << std::endl;
         
-        // Always calculate scale from the grid to preserve anisotropic scaling
-        calculateScaleFromGrid(*points, mesh_units);
+        // Scale is currently in OBJ units. Convert to micrometers now.
+        if (valid_count == 0) {
+            std::cerr << "Warning: no valid grid points were rasterized." << std::endl;
+        }
+        if (uv_is_metric) {
+            scale[0] *= mesh_units;
+            scale[1] *= mesh_units;
+            std::cout << "Scale from UV (micrometers): " << scale[0] << ", " << scale[1] << std::endl;
+        } else {
+            // Measure from 3D to preserve anisotropy and noise-robustness
+            calculateScaleFromGrid(*points, mesh_units);
+        }
         
         return new QuadSurface(points, scale);
     }
@@ -250,6 +267,15 @@ public:
     
 private:
     void rasterizeTriangle(cv::Mat_<cv::Vec3f>& points, const Face& face) {
+        // Validate indices
+        for (int k = 0; k < 3; ++k) {
+            if (face.v[k] < 0 || face.v[k] >= (int)vertices.size()) {
+                return; // skip invalid vertex indices
+            }
+            if (face.vt[k] < 0 || face.vt[k] >= (int)uvs.size()) {
+                return; // skip faces with missing/invalid UVs
+            }
+        }
         // Get triangle vertices and UVs
         cv::Vec3f v0 = vertices[face.v[0]].pos;
         cv::Vec3f v1 = vertices[face.v[1]].pos;
@@ -262,17 +288,19 @@ private:
         // Transform UVs to grid coordinates
         // Map from [uv_min, uv_max] to [0, grid_size-1]
         cv::Vec2f uv_range = uv_max - uv_min;
+        const float rx = std::max(uv_range[0], 1e-12f);
+        const float ry = std::max(uv_range[1], 1e-12f);
         uv0 = (uv0 - uv_min);
-        uv0[0] = uv0[0] / uv_range[0] * (grid_size[0] - 1);
-        uv0[1] = uv0[1] / uv_range[1] * (grid_size[1] - 1);
+        uv0[0] = uv0[0] / rx * (grid_size[0] - 1);
+        uv0[1] = uv0[1] / ry * (grid_size[1] - 1);
         
         uv1 = (uv1 - uv_min);
-        uv1[0] = uv1[0] / uv_range[0] * (grid_size[0] - 1);
-        uv1[1] = uv1[1] / uv_range[1] * (grid_size[1] - 1);
+        uv1[0] = uv1[0] / rx * (grid_size[0] - 1);
+        uv1[1] = uv1[1] / ry * (grid_size[1] - 1);
         
         uv2 = (uv2 - uv_min);
-        uv2[0] = uv2[0] / uv_range[0] * (grid_size[0] - 1);
-        uv2[1] = uv2[1] / uv_range[1] * (grid_size[1] - 1);
+        uv2[0] = uv2[0] / rx * (grid_size[0] - 1);
+        uv2[1] = uv2[1] / ry * (grid_size[1] - 1);
         
         // Find bounding box in grid coordinates
         int min_x = std::max(0, static_cast<int>(std::floor(std::min({uv0[0], uv1[0], uv2[0]}))) - 1);
@@ -313,7 +341,12 @@ private:
         float dot11 = v1.dot(v1);
         float dot12 = v1.dot(v2);
         
-        float invDenom = 1.0f / (dot00 * dot11 - dot01 * dot01);
+        const float denom = (dot00 * dot11 - dot01 * dot01);
+        if (std::fabs(denom) < 1e-20f || !std::isfinite(denom)) {
+            // Degenerate triangle in UV space -> mark "outside"
+            return cv::Vec3f(-1.f, -1.f, -1.f);
+        }
+        float invDenom = 1.0f / denom;
         float u = (dot11 * dot02 - dot01 * dot12) * invDenom;
         float v = (dot00 * dot12 - dot01 * dot02) * invDenom;
         
@@ -323,36 +356,75 @@ private:
 
 int main(int argc, char *argv[])
 {
-    if (argc < 3 || argc > 5) {
-        std::cout << "usage: " << argv[0] << " <input.obj> <output_directory> [stretch_factor] [mesh_units]" << std::endl;
+    if (argc < 3) {
+        std::cout << "usage: " << argv[0]
+                  << " <input.obj> <output_directory> [stretch_factor] [mesh_units]"
+                  << " [--uv-metric] [--uv-to-obj=<ratio>]" << std::endl;
         std::cout << "Converts an OBJ file to tifxyz format" << std::endl;
         std::cout << std::endl;
         std::cout << "Parameters:" << std::endl;
-        std::cout << "  stretch_factor: UV scaling factor (default: 1000.0)" << std::endl;
-        std::cout << "  mesh_units: Units of the mesh coordinates in micrometers (default: 1.0)" << std::endl;
+        std::cout << "  stretch_factor: UV scaling factor (default: 1.0)" << std::endl;
+        std::cout << "  mesh_units    : micrometers per OBJ unit (default: 1.0)" << std::endl;
+        std::cout << "Flags:" << std::endl;
+        std::cout << "  --uv-metric         : UVs are metric (default; UV units == OBJ units unless --uv-to-obj is set)" << std::endl;
+        std::cout << "  --uv-non-metric     : Revert to legacy behavior (measure scale from 3D mesh)" << std::endl;
+        std::cout << "  --uv-to-obj=<ratio> : OBJ units per 1 UV unit (default: 1.0). Only used with --uv-metric." << std::endl;
         std::cout << std::endl;
         std::cout << "Note: Scale factors are automatically calculated from the mesh grid structure." << std::endl;
-        std::cout << "Example: " << argv[0] << " mesh.obj output_dir" << std::endl;
+        std::cout << "Examples:" << std::endl;
+        std::cout << "  " << argv[0] << " mesh.obj outdir                       (legacy behavior)" << std::endl;
+        std::cout << "  " << argv[0] << " mesh.obj outdir 800 1.0 --uv-metric  (UV is metric, OBJ units == UV units)" << std::endl;
+        std::cout << "  " << argv[0] << " mesh.obj outdir --uv-metric --uv-to-obj=0.001" << std::endl;
         return EXIT_SUCCESS;
     }
 
     fs::path obj_path = argv[1];
     fs::path output_dir = argv[2];
-    float stretch_factor = 1000.0f;
-    float mesh_units = 1.0f;  // mesh units in micrometers
+    float stretch_factor = 1.0f;
+    float mesh_units = 1.0f;      // micrometers per OBJ unit
+    bool  uv_metric = true;      // treat UV as metric parametrization
+    float uv_to_obj = 1.0f;       // OBJ units per UV unit (only when uv_metric)
     
-    if (argc >= 4) {
-        stretch_factor = std::atof(argv[3]);
-        if (stretch_factor <= 0) {
-            std::cerr << "Invalid stretch factor: " << stretch_factor << std::endl;
-            return EXIT_FAILURE;
+    // Backward-compatible parsing:
+    // positional numbers: stretch_factor, mesh_units
+    // optional flags: --uv-metric (no-op default)  --uv-non-metric  --uv-to-obj=<ratio>
+    int consumed_numbers = 0;
+    for (int i = 3; i < argc; ++i) {
+        std::string a = argv[i];
+        if (starts_with(a, "--uv-metric")) {
+            uv_metric = true;
+            continue;
         }
-    }
-    
-    if (argc >= 5) {
-        mesh_units = std::atof(argv[4]);
-        if (mesh_units <= 0) {
-            std::cerr << "Invalid mesh units: " << mesh_units << std::endl;
+        if (starts_with(a, "--uv-non-metric")) {
+            uv_metric = false;
+            continue;
+        }
+        if (starts_with(a, "--uv-to-obj=")) {
+            try {
+                uv_to_obj = std::stof(a.substr(std::string("--uv-to-obj=").size()));
+                continue;
+            } catch (...) {
+                std::cerr << "Invalid value for --uv-to-obj\n";
+                return EXIT_FAILURE;
+            }
+        }
+        // numbers (legacy positional)
+        if (consumed_numbers == 0) {
+            stretch_factor = std::atof(a.c_str());
+            if (stretch_factor <= 0) {
+                std::cerr << "Invalid stretch factor: " << a << std::endl;
+                return EXIT_FAILURE;
+            }
+            consumed_numbers++;
+        } else if (consumed_numbers == 1) {
+            mesh_units = std::atof(a.c_str());
+            if (mesh_units <= 0) {
+                std::cerr << "Invalid mesh units: " << a << std::endl;
+                return EXIT_FAILURE;
+            }
+            consumed_numbers++;
+        } else {
+            std::cerr << "Unknown argument: " << a << std::endl;
             return EXIT_FAILURE;
         }
     }
@@ -366,10 +438,18 @@ int main(int argc, char *argv[])
     std::cout << "Input: " << obj_path << std::endl;
     std::cout << "Output: " << output_dir << std::endl;
     std::cout << "Stretch factor: " << stretch_factor << std::endl;
-    std::cout << "Mesh units: " << mesh_units << " micrometers" << std::endl;
+    std::cout << "Mesh units: " << mesh_units << " micrometers per OBJ unit" << std::endl;
+    if (uv_metric) {
+        std::cout << "UV mode: metric (default)" << std::endl;
+        std::cout << "UV->OBJ scale: " << uv_to_obj << " OBJ units / UV unit" << std::endl;
+    } else {
+        std::cout << "UV mode: non-metric (scale measured from mesh)" << std::endl;
+    }
     
     ObjToTifxyzConverter converter;
-    
+    converter.setUVMetric(uv_metric);
+    converter.setUVToObj(uv_to_obj);
+
     // Load OBJ file
     if (!converter.loadObj(obj_path.string())) {
         std::cerr << "Failed to load OBJ file" << std::endl;

--- a/apps/src/vc_tifxyz2obj.cpp
+++ b/apps/src/vc_tifxyz2obj.cpp
@@ -1,3 +1,4 @@
+// vc_tifxyz2obj.cpp
 #include "vc/core/util/Slicing.hpp"
 #include "vc/core/util/Surface.hpp"
 #include "vc/core/types/ChunkedTensor.hpp"
@@ -7,96 +8,212 @@
 
 #include <opencv2/highgui.hpp>
 
+#include <filesystem>
+#include <fstream>
 #include <iomanip>
+#include <iostream>
+#include <cmath>
 
 namespace fs = std::filesystem;
-
 using json = nlohmann::json;
 
-int get_add_vertex(std::ofstream &out, cv::Mat_<cv::Vec3f> &points,
-                   cv::Mat_<int> idxs, int &v_idx, cv::Vec2i loc,
-                   bool normalize_uv)
+// ---- small helpers ---------------------------------------------------------
+static inline bool finite3(const cv::Vec3f& v) {
+    return std::isfinite(v[0]) && std::isfinite(v[1]) && std::isfinite(v[2]);
+}
+static inline cv::Vec3f unit_or_default(const cv::Vec3f& n, const cv::Vec3f& def={0.f,0.f,1.f}) {
+    float L2 = n.dot(n);
+    if (!std::isfinite(L2) || L2 <= 1e-24f) return def;
+    cv::Vec3f u = n / std::sqrt(L2);
+    return finite3(u) ? u : def;
+}
+static inline cv::Vec3f fd_fallback_normal(const cv::Mat_<cv::Vec3f>& P, int y, int x) {
+    // Use local finite differences (very cheap) as a robust fallback
+    cv::Vec3f dx(0,0,0), dy(0,0,0);
+    bool okx=false, oky=false;
+
+    if (x+1 < P.cols && P(y,x+1)[0] != -1) { dx = P(y,x+1) - P(y,x); okx=true; }
+    else if (x-1 >= 0 && P(y,x-1)[0] != -1) { dx = P(y,x) - P(y,x-1); okx=true; }
+
+    if (y+1 < P.rows && P(y+1,x)[0] != -1) { dy = P(y+1,x) - P(y,x); oky=true; }
+    else if (y-1 >= 0 && P(y-1,x)[0] != -1) { dy = P(y,x) - P(y-1,x); oky=true; }
+
+    if (okx && oky) return unit_or_default(dx.cross(dy));
+    return {0.f,0.f,1.f};
+}
+// ---------------------------------------------------------------------------
+
+// Adds vertex/texcoord/normal for grid location (y,x) if not already added.
+// Returns the (1-based) OBJ index for this vertex (and matching vt/vn).
+static int get_add_vertex(std::ofstream& out,
+                          const cv::Mat_<cv::Vec3f>& points,
+                          const cv::Mat_<cv::Vec3f>& normals,
+                          cv::Mat_<int>& idxs,
+                          int& v_idx,
+                          cv::Vec2i loc,
+                          bool normalize_uv,
+                          float uv_fac_x,
+                          float uv_fac_y)
 {
+
     if (idxs(loc) == -1) {
         idxs(loc) = v_idx++;
-        cv::Vec3f p = points(loc);
-        out << "v " << p[0] << " " << p[1] << " " << p[2] << std::endl;
+        const cv::Vec3f p = points(loc);
+        out << "v " << p[0] << " " << p[1] << " " << p[2] << '\n';
 
-        // Normalize if flag
-        float u = normalize_uv ? (1.0f * loc[1] / points.cols)
-                               : static_cast<float>(loc[1]);
-        float v = normalize_uv ? (1.0f * loc[0] / points.rows)
-                               : static_cast<float>(loc[0]);
-        out << "vt " << u << " " << v << std::endl;
+        // UVs: scaled by SCALE = 20
+        const float u = normalize_uv ? float(loc[1]) / float(points.cols - 1) : float(loc[1]) * uv_fac_x;
+        const float v = normalize_uv ? float(loc[0]) / float(points.rows - 1) : float(loc[0]) * uv_fac_y;
+        out << "vt " << u << " " << v << '\n';
 
-        cv::Vec3f n = grid_normal(points, {loc[1],loc[0]});
+        // Prefer precomputed per-vertex normal; validate; then fallback.
+        cv::Vec3f n = normals(loc);
+        bool ok = finite3(n);
+        if (ok) n = unit_or_default(n);
 
-        if (n[0] == n[0] && n[1] == n[1] && n[2] == n[2])
-            out << "vn " << n[0] << " " << n[1] << " " << n[2] << std::endl;
-        else
-            out << "vn 0 0 0" << std::endl;
+        if (!ok || (n[0] == 0.f && n[1] == 0.f && n[2] == 0.f)) {
+            // fall back to grid_normal (expects x,y), then to finite-diff
+            cv::Vec3f ng = grid_normal(points, cv::Vec3f(float(loc[1]), float(loc[0]), 0.f));
+            if (finite3(ng)) n = unit_or_default(ng);
+            else             n = fd_fallback_normal(points, loc[0], loc[1]);
+        }
+        out << "vn " << n[0] << " " << n[1] << " " << n[2] << '\n';
     }
 
     return idxs(loc);
 }
 
-void surf_write_obj(QuadSurface *surf, const fs::path &out_fn,
-                    bool normalize_uv)
+static cv::Mat_<cv::Vec3f> build_vertex_normals_from_faces(
+        const cv::Mat_<cv::Vec3f>& P)
+{
+    cv::Mat_<cv::Vec3f> nsum(P.size(), cv::Vec3f(0,0,0));
+    cv::Mat_<int>       ncnt(P.size(), 0);
+
+    for (int j = 0; j < P.rows - 1; ++j) {
+        for (int i = 0; i < P.cols - 1; ++i) {
+            if (!loc_valid(P, cv::Vec2d(j, i))) continue;
+
+            const cv::Vec3f p00 = P(j,   i  );
+            const cv::Vec3f p01 = P(j,   i+1);
+            const cv::Vec3f p10 = P(j+1, i  );
+            const cv::Vec3f p11 = P(j+1, i+1);
+
+            // Face winding matches your 'f' lines:
+            // f c10 c00 c01   and   f c10 c01 c11
+            const cv::Vec3f n1 = (p00 - p10).cross(p01 - p10); // (c10,c00,c01)
+            const cv::Vec3f n2 = (p01 - p10).cross(p11 - p10); // (c10,c01,c11)
+
+            auto add = [&](int y, int x, const cv::Vec3f& n) {
+                nsum(y,x) += n;
+                ncnt(y,x) += 1;
+            };
+            add(j+1,i, n1); add(j,i, n1); add(j,i+1, n1);
+            add(j+1,i, n2); add(j,i+1, n2); add(j+1,i+1, n2);
+        }
+    }
+
+    // normalize (and guard against degenerate cases)
+    for (int y = 0; y < P.rows; ++y)
+        for (int x = 0; x < P.cols; ++x) {
+            cv::Vec3f n = nsum(y,x);
+            float L2 = n.dot(n);
+            if (ncnt(y,x) > 0 && std::isfinite(L2) && L2 > 1e-20f)
+                nsum(y,x) = n / std::sqrt(L2);
+            else
+                nsum(y,x) = cv::Vec3f(0,0,1); // safe default (rarely used now)
+        }
+
+    return nsum;
+}
+
+static void surf_write_obj(QuadSurface *surf, const fs::path &out_fn, bool normalize_uv)
 {
     cv::Mat_<cv::Vec3f> points = surf->rawPoints();
     cv::Mat_<int> idxs(points.size(), -1);
 
-    cv::Mat_<cv::Vec3f> coords, normals;
-
     std::ofstream out(out_fn);
-
+    if (!out) {
+        std::cerr << "Failed to open for write: " << out_fn << "\n";
+        return;
+    }
     out << std::fixed << std::setprecision(6);
 
-    std::cout << "Point dims: " << points.size() << " cols: " << points.cols << " rows: " << points.rows << std::endl;
+    cv::Mat_<cv::Vec3f> normals = build_vertex_normals_from_faces(points);
+
+    std::cout << "Point dims: " << points.size()
+              << " cols: " << points.cols
+              << " rows: " << points.rows << std::endl;
+
+    // Derive UV scale from meta: surf->scale() is typically micrometers-per-pixel (or similar).
+    // You asked to use the reciprocal (1/scale) as the multiplier.
+    cv::Vec2f s = surf->scale();           // [sx, sy]
+    float uv_fac_x = (std::isfinite(s[0]) && s[0] > 0.f) ? 1.0f / s[0] : 1.0f;
+    float uv_fac_y = (std::isfinite(s[1]) && s[1] > 0.f) ? 1.0f / s[1] : 1.0f;
+    if (normalize_uv) {
+        std::cout << "UVs: normalized to [0,1]\n";
+    } else {
+        std::cout << "UVs: scaled by 1/scale from meta.json  (u*= " << uv_fac_x
+                  << ", v*= " << uv_fac_y << " )\n";
+        std::cout << "      (meta scale = [" << s[0] << ", " << s[1] << "])\n";
+    }
 
     int v_idx = 1;
-    for(int j=0;j<points.rows-1;j++)
-        for(int i=0;i<points.cols-1;i++)
-            if (loc_valid(points, {j,i}))
+    for (int j = 0; j < points.rows - 1; ++j)
+        for (int i = 0; i < points.cols - 1; ++i)
+            if (loc_valid(points, cv::Vec2d(j, i)))
             {
-                int c00 = get_add_vertex(out, points, idxs, v_idx, {j,i}, normalize_uv);
-                int c01 = get_add_vertex(out, points, idxs, v_idx, {j,i+1}, normalize_uv);
-                int c10 = get_add_vertex(out, points, idxs, v_idx, {j+1,i}, normalize_uv);
-                int c11 = get_add_vertex(out, points, idxs, v_idx, {j+1,i+1}, normalize_uv);
+                const int c00 = get_add_vertex(out, points, normals, idxs, v_idx, {j,   i  }, normalize_uv, uv_fac_x, uv_fac_y);
+                const int c01 = get_add_vertex(out, points, normals, idxs, v_idx, {j,   i+1}, normalize_uv, uv_fac_x, uv_fac_y);
+                const int c10 = get_add_vertex(out, points, normals, idxs, v_idx, {j+1, i  }, normalize_uv, uv_fac_x, uv_fac_y);
+                const int c11 = get_add_vertex(out, points, normals, idxs, v_idx, {j+1, i+1}, normalize_uv, uv_fac_x, uv_fac_y);
+                // faces unchanged: use same index for v/vt/vn
+                out << "f " << c10 << "/" << c10 << "/" << c10 << " "
+                           << c00 << "/" << c00 << "/" << c00 << " "
+                           << c01 << "/" << c01 << "/" << c01 << '\n';
 
-                out << "f " << c10 << "/" << c10 << "/" << c10 << " " << c00 << "/" << c00 << "/" << c00 << " " << c01 << "/" << c01 << "/" << c01 << std::endl;
-                out << "f " << c10 << "/" << c10 << "/" << c10 << " " << c01 << "/" << c01 << "/" << c01 << " " << c11 << "/" << c11 << "/" << c11 << std::endl;
+                out << "f " << c10 << "/" << c10 << "/" << c10 << " "
+                           << c01 << "/" << c01 << "/" << c01 << " "
+                           << c11 << "/" << c11 << "/" << c11 << '\n';
             }
 }
 
 int main(int argc, char *argv[])
 {
-    if (argc < 3 || argc > 4) {
-        std::cout << "usage: " << argv[0]
-                  << " <tiffxyz> <obj> [--normalize-uv]" << std::endl;
+    if (argc == 2 && (std::string(argv[1]) == "-h" || std::string(argv[1]) == "--help")) {
+        std::cout << "usage: " << argv[0] << " <tiffxyz> <obj> [--normalize-uv]\n";
         return EXIT_SUCCESS;
     }
 
-    fs::path seg_path = argv[1];
-    fs::path obj_path = argv[2];
+    if (argc < 3 || argc > 4) {
+        std::cerr << "error: wrong number of arguments\n"
+                  << "usage: " << argv[0] << " <tiffxyz> <obj> [--normalize-uv]\n";
+        return EXIT_FAILURE;
+    }
 
-    // Default behaviour: (un-normalized UVs)
     bool normalize_uv = false;
-    if (argc == 4 && std::string(argv[3]) == "--normalize-uv")
-        normalize_uv = true;
+    if (argc == 4) {
+        if (std::string(argv[3]) == "--normalize-uv")
+            normalize_uv = true;
+        else {
+            std::cerr << "error: unknown option '" << argv[3] << "'\n";
+            return EXIT_FAILURE;
+        }
+    }
+
+    const fs::path seg_path = argv[1];
+    const fs::path obj_path = argv[2];
 
     QuadSurface *surf = nullptr;
     try {
         surf = load_quad_from_tifxyz(seg_path);
     }
     catch (...) {
-        std::cout << "error when loading: " << seg_path << std::endl;
+        std::cerr << "error when loading: " << seg_path << std::endl;
         return EXIT_FAILURE;
     }
 
     surf_write_obj(surf, obj_path, normalize_uv);
 
     delete surf;
-
     return EXIT_SUCCESS;
 }

--- a/scripts/flatboi.py
+++ b/scripts/flatboi.py
@@ -1,0 +1,367 @@
+import igl
+import os
+import argparse
+import numpy as np
+import open3d as o3d
+from PIL import Image
+from math import sqrt
+from tqdm import tqdm
+from pathlib import Path
+from datetime import datetime, timezone
+
+Image.MAX_IMAGE_PIXELS = None
+
+# --- W&B minimal integration -------------------------------------------------
+class WBLogger:
+    """
+    Thin wrapper so you can call:
+        logger = WBLogger(obj_path, n_iters)
+        logger.log_initial_stretch(stretch_init)
+        logger.log_energy(sym_dirichlet, it)
+        logger.log_final_stretch(stretch_final)
+        logger.finish()
+    If wandb isn't installed/available, this becomes a no-op.
+    """
+    def __init__(self, obj_path, n_iters):
+        self.enabled = False
+        try:
+            import wandb  # noqa: F401
+            self.wandb = wandb
+        except Exception:
+            self.wandb = None
+            return
+
+        run_name = self._derive_names(obj_path)
+        ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        project = "flattening"
+        entity = os.environ.get("WANDB_ENTITY") or os.environ.get("WANDB_ORG")
+        print(f"Entity {entity}")
+        try:
+            self.run = self.wandb.init(
+                project=project,
+                entity=entity,            # set via env: WANDB_ENTITY=your-org
+                name=f"{run_name}_{ts}",
+                config={
+                    "obj_path": str(obj_path),
+                    "iterations": int(n_iters),
+                },
+            )
+            # make 'iter' the step metric for energy curves
+            self.wandb.define_metric("iter")
+            self.wandb.define_metric("symmetric_dirichlet", step_metric="iter")
+            self.wandb.define_metric("stretch/*", step_metric="iter")
+            self.enabled = True
+        except Exception:
+            # If init fails, silently disable logging
+            self.enabled = False
+
+    @staticmethod
+    def _derive_names(obj_path):
+        """
+        Run:     Volume + OBJ filename stem.
+        Fallbacks: parent folder name -> 'flatboi'.
+        """
+        p = Path(obj_path).resolve()
+        volume = None
+        for parent in p.parents:
+            if parent.name.endswith(".volpkg"):
+                volume = parent.stem   # strip '.volpkg'
+                break
+        if not volume:
+            volume = p.parent.name or "flatboi"
+
+        run_name = volume + "_" + p.stem
+        return run_name
+
+    def log_dict(self, d: dict):
+        if self.enabled and d:
+            try:
+                self.wandb.log(d)
+            except Exception:
+                pass
+
+    def log_energy(self, value, step):
+        if self.enabled and value is not None:
+            try:
+                self.wandb.log({"symmetric_dirichlet": float(value), "iter": int(step)})
+            except Exception:
+                pass
+
+    def finish(self):
+        if self.enabled:
+            try:
+                self.wandb.finish()
+            except Exception:
+                pass
+# ---------------------------------------------------------------------------
+
+def print_array_to_file(array, file_path):
+    # Open the file in write mode
+    with open(file_path, 'w') as file:
+        # Write each element of the array to the file
+        for element in array:
+            file.write(str(element) + '\n')
+
+class Flatboi:
+    input_obj: str
+    max_iter: int
+    def __init__(self, obj_path: str, max_iter: int):
+        self.input_obj = obj_path
+        self.max_iter = max_iter
+        self.read_mesh()
+
+    def read_mesh(self):
+        self.mesh = o3d.io.read_triangle_mesh(self.input_obj)
+        self.vertices = np.asarray(self.mesh.vertices, dtype=np.float64)
+        self.triangles = np.asarray(self.mesh.triangles, dtype=np.int32)
+        self.vc3d_uvs = np.asarray(self.mesh.triangle_uvs, dtype=np.float64) # read VC3D flattening
+
+    def generate_boundary(self):
+        return igl.boundary_loop(self.triangles)
+    
+    def harmonic_ic(self):
+        bnd = self.generate_boundary()
+        bnd_uv = igl.map_vertices_to_circle(self.vertices, bnd)
+        uv = igl.harmonic(self.vertices, self.triangles, bnd, bnd_uv, 1)
+        return bnd, bnd_uv, uv
+    
+    def original_ic(self):
+        uv = np.zeros((self.vertices.shape[0], 2), dtype=np.float64)
+        uvs = self.vc3d_uvs.reshape((self.triangles.shape[0], self.triangles.shape[1], 2))
+        for t in range(self.triangles.shape[0]):
+            for v in range(self.triangles.shape[1]):
+                uv[self.triangles[t,v]] = uvs[t,v]
+        
+        bnd = self.generate_boundary()
+        bnd_uv = np.zeros((bnd.shape[0], 2), dtype=np.float64)
+
+        for i in range(bnd.shape[0]):
+            bnd_uv[i] = uv[bnd[i]]
+
+        return bnd, bnd_uv, uv
+    
+    def slim(self, initial_condition='original', logger=None):
+        if initial_condition == 'original':
+            bnd, bnd_uv, uv = self.original_ic()
+            l2_mean, l2_median, linf, area_err = self.stretch_metrics(uv)
+            print(f"Starting metrics from VC3D flattening -- "
+                  f"L2(mean): {l2_mean:.5f}, L2(median): {l2_median:.5f}, "
+                  f"Linf: {linf:.5f}, Area Error: {area_err:.5f}")
+            # log at iter=0 so curves start at the initial condition
+            if logger:
+                logger.log_dict({
+                    "iter": 0,
+                    "stretch/l2_mean": float(l2_mean),
+                    "stretch/l2_median": float(l2_median),
+                    "stretch/linf": float(linf),
+                    "stretch/area_error": float(area_err),
+                })
+
+        elif initial_condition == 'harmonic':
+            bnd, bnd_uv, uv = self.harmonic_ic()
+
+        slim = igl.SLIM(self.vertices, self.triangles, v_init=uv, b=bnd, bc=bnd_uv, energy_type=igl.SLIM_ENERGY_TYPE_SYMMETRIC_DIRICHLET, soft_penalty=0)
+
+        energies = np.empty(self.max_iter + 1, dtype=float)
+        energies[0] = slim.energy()
+        # log initial energy (iter=0)
+        if logger:
+            logger.log_energy(energies[0], step=0)
+
+        pbar      = tqdm(range(self.max_iter), desc="Optimisation")
+
+        for i in pbar:
+            slim.solve(1)
+
+            energy = slim.energy()
+            energies[i + 1] = energy
+
+            # put the current energy in the bar’s tail
+            # {:.3e} → scientific notation; tweak as you like
+            pbar.set_postfix(E=f"{energy:.3e}")
+            if logger:
+                logger.log_energy(energy, step=i+1)
+                # log stretch every 20 iterations
+                if ((i + 1) % 20) == 0:
+                    l2m, l2med, linf_v, area_v = self.stretch_metrics(slim.vertices())
+                    logger.log_dict({
+                        "iter": i + 1,
+                        "stretch/l2_mean": float(l2m),
+                        "stretch/l2_median": float(l2med),
+                        "stretch/linf": float(linf_v),
+                        "stretch/area_error": float(area_v),
+                    })
+        # ensure we also log the final stretch if not already on a 20-step boundary
+        if (self.max_iter % 20) != 0:
+            l2_mean_f, l2_median_f, linf_f, area_err_f = self.stretch_metrics(slim.vertices())
+            if logger:
+                logger.log_dict({
+                    "iter": self.max_iter,
+                    "stretch/l2_mean": float(l2_mean_f),
+                    "stretch/l2_median": float(l2_median_f),
+                    "stretch/linf": float(linf_f),
+                    "stretch/area_error": float(area_err_f),
+                })
+        else:
+            # already logged at the last iteration due to %20==0
+            l2_mean_f, l2_median_f, linf_f, area_err_f = self.stretch_metrics(slim.vertices())
+
+        print(f"Stretch metrics SLIM from {initial_condition} -- "
+              f"L2(mean): {l2_mean_f:.5f}, L2(median): {l2_median_f:.5f}, "
+              f"Linf: {linf_f:.5f}, Area Error: {area_err_f:.5f}")
+        
+        return slim.vertices(), energies
+    
+    @staticmethod
+    def shift(uv):
+        uv_min = np.min(uv, axis=0)
+        new_uv = (uv - uv_min)
+        return new_uv
+    
+    def save_obj(self, uv):
+        input_directory = os.path.dirname(self.input_obj)
+        base_file_name, _ = os.path.splitext(os.path.basename(self.input_obj))
+        obj_path = os.path.join(input_directory, f"{base_file_name}_flatboi.obj")
+        shifted_uv = self.shift(uv)
+        slim_uvs = np.zeros((self.triangles.shape[0],3,2), dtype=np.float64)
+        for t in range(self.triangles.shape[0]):
+            for v in range(self.triangles.shape[1]):
+                slim_uvs[t,v,:] = shifted_uv[self.triangles[t,v]]
+        slim_uvs = slim_uvs.reshape(-1,2)
+        self.mesh.triangle_uvs = o3d.utility.Vector2dVector(slim_uvs)
+        o3d.io.write_triangle_mesh(obj_path, self.mesh)
+
+    def stretch_triangle(self, triangle_3d, triangle_2d):
+        q1, q2, q3 = triangle_3d
+
+        s1, t1 = triangle_2d[0]
+        s2, t2 = triangle_2d[1]
+        s3, t3 = triangle_2d[2]
+
+        A = ((s2-s1)*(t3-t1)-(s3-s1)*(t2-t1))/2 # 2d area
+        Ss = (q1*(t2-t3)+q2*(t3-t1)+q3*(t1-t2))/(2*A)
+        St = (q1*(s3-s2)+q2*(s1-s3)+q3*(s2-s1))/(2*A)
+        a = np.dot(Ss,Ss)
+        b = np.dot(Ss,St)
+        c = np.dot(St,St)
+
+        G = sqrt(((a+c)+sqrt((a-c)**2+4*b**2))/2)
+
+        L2 = sqrt((a+c)/2)
+
+        ab = np.linalg.norm(q2-q1)
+        bc = np.linalg.norm(q3-q2)
+        ca = np.linalg.norm(q1-q3)
+        s = (ab+bc+ca)/2
+        area = sqrt(s*(s-ab)*(s-bc)*(s-ca)) # 3d area
+
+        
+        return L2, G, area, abs(A)
+    
+    @staticmethod
+    def weighted_median(data, weights):
+        # Sort data and weights by the data values
+        sorted_indices = np.argsort(data)
+        sorted_data = np.array(data)[sorted_indices]
+        sorted_weights = np.array(weights)[sorted_indices]
+
+        # Compute the cumulative sum of weights
+        cumsum_sorted_weights = np.cumsum(sorted_weights)
+        
+        # Get the sum of weights
+        total_weight = cumsum_sorted_weights[-1]
+        
+        # Find the index where the cumulative sum of weights equals or exceeds half the total weight
+        half_weight_index = np.where(cumsum_sorted_weights >= total_weight / 2)[0][0]
+        
+        # Return the corresponding data value
+        return sorted_data[half_weight_index]
+
+    def stretch_metrics(self, uv):
+        if len(uv.shape) == 2:
+            temp = uv.copy()
+            uv = np.zeros((self.triangles.shape[0],3,2), dtype=np.float64)
+            for t in range(self.triangles.shape[0]):
+                for v in range(self.triangles.shape[1]):
+                    uv[t,v,:] = temp[self.triangles[t,v]]
+
+        l2_all = np.zeros(self.triangles.shape[0])
+        linf_all = np.zeros(self.triangles.shape[0])
+        area_all = np.zeros(self.triangles.shape[0])
+        area2d_all = np.zeros(self.triangles.shape[0])
+        per_triangle_area = np.zeros(self.triangles.shape[0])
+
+        nominator = 0
+        for t in range(self.triangles.shape[0]):
+            t3d = [self.vertices[self.triangles[t,i]] for i in range(self.triangles.shape[1])]
+            t2d = [uv[t,i] for i in range(self.triangles.shape[1])]
+
+            l2, linf, area, area2d = self.stretch_triangle(t3d, t2d)
+
+            linf_all[t] = linf
+            area_all[t] = area
+            area2d_all[t] = area2d
+            l2_all[t] = l2**2
+            nominator += l2_all[t]*area_all[t]
+            
+        l2_mesh_mean = sqrt( nominator / np.sum(area_all))
+        l2_mesh_median = self.weighted_median(l2_all, area_all)
+        linf_mesh = np.max(linf_all)
+
+        alpha = area_all/np.sum(area_all)
+        beta = area2d_all/np.sum(area2d_all)
+
+        for t in range(self.triangles.shape[0]):
+            if alpha[t] > beta[t]:
+                per_triangle_area[t] = 1 - beta[t]/alpha[t]
+            else:
+                per_triangle_area[t] = 1 - alpha[t]/beta[t]
+        
+        area_err = float(np.mean(per_triangle_area))
+        return l2_mesh_mean, l2_mesh_median, linf_mesh, area_err
+        
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Reflatten .obj")
+    parser.add_argument('input', type=str, help='Path to .obj to reflatten.')
+    parser.add_argument('iter', type=int, help='Max number of iterations.')
+
+    args = parser.parse_args()
+
+    # Check if the input file exists and is a .obj file
+    if not os.path.exists(args.input):
+        print(f"Error: The file '{args.input}' does not exist.")
+        exit(1)
+
+    if not args.input.lower().endswith('.obj'):
+        print(f"Error: The file '{args.input}' is not a .obj file.")
+        exit(1)
+
+    assert args.iter > 0, "Max number of iterations should be positive."
+
+    # Get the directory of the input file
+    input_directory = os.path.dirname(args.input)
+    # Filename for the energies file
+    energies_file = os.path.join(input_directory, 'energies_flatboi.txt')
+    try:
+        # Init W&B logger (no-op if wandb not installed or init fails)
+        _logger = WBLogger(args.input, args.iter)
+
+        flatboi = Flatboi(args.input, args.iter)
+        original_uvs, original_energies = flatboi.slim(initial_condition='original', logger=_logger)
+        print(f"Symmetric Dirichlet Energy per iter: {original_energies}")
+
+        # Optionally persist energies to a file near the mesh
+        input_directory = os.path.dirname(args.input)
+        base_file_name, _ = os.path.splitext(os.path.basename(args.input))
+        energies_file = os.path.join(input_directory, f"{base_file_name}_energies_flatboi.txt")
+        np.savetxt(energies_file, original_energies, fmt="%.10g")
+
+        flatboi.save_obj(original_uvs)
+
+        _logger.finish()
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        exit(1)
+
+

--- a/ubuntu-22.04-jammy.Dockerfile
+++ b/ubuntu-22.04-jammy.Dockerfile
@@ -17,6 +17,16 @@ RUN apt-get -y install libblosc-dev libspdlog-dev
 RUN apt-get -y install libgsl-dev libsdl2-dev libcurl4-openssl-dev
 RUN apt-get -y install file curl unzip
 
+# ----- Python 3.10 env (micromamba) + Open3D runtime deps -----
+# Open3D needs GL/GLib bits even for headless usage.
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+        ca-certificates bzip2 \
+        libgl1 libglib2.0-0 libx11-6 libxext6 libxrender1 libsm6 libegl1 \
+     && rm -rf /var/lib/apt/lists/*
+    
+# Install micromamba (tiny conda) to get a clean Python 3.10
+RUN curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj -C /usr/local/bin bin/micromamba --strip-components=1
+
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then \
         curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
@@ -29,6 +39,22 @@ RUN ARCH=$(uname -m) && \
     ./aws/install && \
     rm -rf awscliv2.zip aws
 
+ # Create Python 3.10 env and install your packages via pip
+ENV MAMBA_ROOT_PREFIX=/opt/micromamba
+SHELL ["/bin/bash", "-lc"]
+RUN micromamba create -y -n py310 -c conda-forge python=3.10 pip \
+ && micromamba run -n py310 python -m pip install --upgrade pip \
+ && micromamba run -n py310 pip install --no-cache-dir \
+      numpy==1.26.4 \
+      pillow \
+      tqdm \
+      libigl==2.5.1 \
+      open3d==0.18.0 \
+      wandb
+
+# Make this Python visible to subsequent steps
+ENV PATH="/opt/micromamba/envs/py310/bin:${PATH}"
+
 COPY . /src
 RUN rm /src/CMakeCache.txt || true
 
@@ -37,7 +63,7 @@ RUN mkdir /src/build
 WORKDIR /src/build
 
 RUN cmake -DVC_WITH_CUDA_SPARSE=off /src
-RUN make -j$(nproc --all)
+RUN make -j"$(nproc --all)"
 
 RUN cpack -G DEB -V
 
@@ -45,3 +71,5 @@ RUN dpkg -i /src/build/pkgs/vc3d*.deb
 
 RUN apt-get -y autoremove
 RUN rm -r /src
+
+ENV WANDB_ENTITY="vesuvius-challenge"

--- a/ubuntu-24.04-noble-s3.Dockerfile
+++ b/ubuntu-24.04-noble-s3.Dockerfile
@@ -12,6 +12,16 @@ RUN apt-get -y install libceres-dev xtensor-dev libopencv-dev libxsimd-dev libbl
 RUN apt-get -y install libgsl-dev libsdl2-dev libcurl4-openssl-dev
 RUN apt-get -y install file curl unzip
 
+# ----- Python 3.10 env (micromamba) + Open3D runtime deps -----
+# Open3D needs GL/GLib bits even for headless usage.
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+        ca-certificates bzip2 \
+        libgl1 libglib2.0-0 libx11-6 libxext6 libxrender1 libsm6 libegl1 \
+     && rm -rf /var/lib/apt/lists/*
+    
+# Install micromamba (tiny conda) to get a clean Python 3.10
+RUN curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj -C /usr/local/bin bin/micromamba --strip-components=1
+
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then \
         curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
@@ -24,6 +34,21 @@ RUN ARCH=$(uname -m) && \
     ./aws/install && \
     rm -rf awscliv2.zip aws
 
+# Create Python 3.10 env and install your packages via pip
+ENV MAMBA_ROOT_PREFIX=/opt/micromamba
+SHELL ["/bin/bash", "-lc"]
+RUN micromamba create -y -n py310 -c conda-forge python=3.10 pip \
+ && micromamba run -n py310 python -m pip install --upgrade pip \
+ && micromamba run -n py310 pip install --no-cache-dir \
+      numpy==1.26.4 \
+      pillow \
+      tqdm \
+      libigl==2.5.1 \
+      open3d==0.18.0 \
+      wandb
+
+# Make this Python visible to subsequent steps
+ENV PATH="/opt/micromamba/envs/py310/bin:${PATH}"
 
 COPY . /src
 RUN rm /src/CMakeCache.txt || true
@@ -33,7 +58,7 @@ RUN mkdir /src/build
 WORKDIR /src/build
 
 RUN cmake -DVC_WITH_CUDA_SPARSE=off /src
-RUN make -j$(nproc --all)
+RUN make -j"$(nproc --all)"
 
 RUN cpack -G DEB -V
 
@@ -50,5 +75,7 @@ RUN chmod +x /usr/local/bin/goofys
 
 COPY docker_s3_entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENV WANDB_ENTITY="vesuvius-challenge"
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/ubuntu-24.04-noble.Dockerfile
+++ b/ubuntu-24.04-noble.Dockerfile
@@ -12,6 +12,16 @@ RUN apt-get -y install libceres-dev xtensor-dev libopencv-dev libxsimd-dev libbl
 RUN apt-get -y install libgsl-dev libsdl2-dev libcurl4-openssl-dev
 RUN apt-get -y install file curl unzip
 
+# ----- Python 3.10 env (micromamba) + Open3D runtime deps -----
+# Open3D needs GL/GLib bits even for headless usage.
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+        ca-certificates bzip2 \
+        libgl1 libglib2.0-0 libx11-6 libxext6 libxrender1 libsm6 libegl1 \
+     && rm -rf /var/lib/apt/lists/*
+    
+# Install micromamba (tiny conda) to get a clean Python 3.10
+RUN curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj -C /usr/local/bin bin/micromamba --strip-components=1
+
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then \
         curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
@@ -24,6 +34,21 @@ RUN ARCH=$(uname -m) && \
     ./aws/install && \
     rm -rf awscliv2.zip aws
 
+# Create Python 3.10 env and install your packages via pip
+ENV MAMBA_ROOT_PREFIX=/opt/micromamba
+SHELL ["/bin/bash", "-lc"]
+RUN micromamba create -y -n py310 -c conda-forge python=3.10 pip \
+ && micromamba run -n py310 python -m pip install --upgrade pip \
+ && micromamba run -n py310 pip install --no-cache-dir \
+      numpy==1.26.4 \
+      pillow \
+      tqdm \
+      libigl==2.5.1 \
+      open3d==0.18.0 \
+      wandb
+
+# Make this Python visible to subsequent steps
+ENV PATH="/opt/micromamba/envs/py310/bin:${PATH}"
 
 COPY . /src
 RUN rm /src/CMakeCache.txt || true
@@ -33,7 +58,7 @@ RUN mkdir /src/build
 WORKDIR /src/build
 
 RUN cmake -DVC_WITH_CUDA_SPARSE=off /src
-RUN make -j$(nproc --all)
+RUN make -j"$(nproc --all)"
 
 RUN cpack -G DEB -V
 
@@ -41,3 +66,5 @@ RUN dpkg -i /src/build/pkgs/vc3d*.deb
 
 RUN apt-get -y autoremove
 RUN rm -r /src
+
+ENV WANDB_ENTITY="vesuvius-challenge"

--- a/ubuntu-24.10-oracular.Dockerfile
+++ b/ubuntu-24.10-oracular.Dockerfile
@@ -11,6 +11,16 @@ RUN apt-get -y install libceres-dev xtensor-dev libopencv-dev libxsimd-dev libbl
 RUN apt-get -y install libgsl-dev libsdl2-dev libcurl4-openssl-dev
 RUN apt-get -y install file curl unzip
 
+# ----- Python 3.10 env (micromamba) + Open3D runtime deps -----
+# Open3D needs GL/GLib bits even for headless usage.
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+        ca-certificates bzip2 \
+        libgl1 libglib2.0-0 libx11-6 libxext6 libxrender1 libsm6 libegl1 \
+     && rm -rf /var/lib/apt/lists/*
+    
+# Install micromamba (tiny conda) to get a clean Python 3.10
+RUN curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj -C /usr/local/bin bin/micromamba --strip-components=1
+
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then \
         curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
@@ -23,6 +33,21 @@ RUN ARCH=$(uname -m) && \
     ./aws/install && \
     rm -rf awscliv2.zip aws
 
+# Create Python 3.10 env and install your packages via pip
+ENV MAMBA_ROOT_PREFIX=/opt/micromamba
+SHELL ["/bin/bash", "-lc"]
+RUN micromamba create -y -n py310 -c conda-forge python=3.10 pip \
+ && micromamba run -n py310 python -m pip install --upgrade pip \
+ && micromamba run -n py310 pip install --no-cache-dir \
+      numpy==1.26.4 \
+      pillow \
+      tqdm \
+      libigl==2.5.1 \
+      open3d==0.18.0 \
+      wandb
+
+# Make this Python visible to subsequent steps
+ENV PATH="/opt/micromamba/envs/py310/bin:${PATH}"
 
 COPY . /src
 RUN rm /src/CMakeCache.txt || true
@@ -32,7 +57,7 @@ RUN mkdir /src/build
 WORKDIR /src/build
 
 RUN cmake -DVC_WITH_CUDA_SPARSE=off /src
-RUN make -j$(nproc --all)
+RUN make -j"$(nproc --all)"
 
 RUN cpack -G DEB -V
 
@@ -40,3 +65,5 @@ RUN dpkg -i /src/build/pkgs/vc3d*.deb
 
 RUN apt-get -y autoremove
 RUN rm -r /src
+
+ENV WANDB_ENTITY="vesuvius-challenge"

--- a/ubuntu-25.04-plucky.Dockerfile
+++ b/ubuntu-25.04-plucky.Dockerfile
@@ -11,6 +11,16 @@ RUN apt-get -y install libceres-dev xtensor-dev libopencv-dev libxsimd-dev libbl
 RUN apt-get -y install libgsl-dev libsdl2-dev libcurl4-openssl-dev
 RUN apt-get -y install file curl unzip
 
+# ----- Python 3.10 env (micromamba) + Open3D runtime deps -----
+# Open3D needs GL/GLib bits even for headless usage.
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+        ca-certificates bzip2 \
+        libgl1 libglib2.0-0 libx11-6 libxext6 libxrender1 libsm6 libegl1 \
+     && rm -rf /var/lib/apt/lists/*
+    
+# Install micromamba (tiny conda) to get a clean Python 3.10
+RUN curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj -C /usr/local/bin bin/micromamba --strip-components=1
+
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then \
         curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
@@ -23,6 +33,22 @@ RUN ARCH=$(uname -m) && \
     ./aws/install && \
     rm -rf awscliv2.zip aws
 
+# Create Python 3.10 env and install your packages via pip
+ENV MAMBA_ROOT_PREFIX=/opt/micromamba
+SHELL ["/bin/bash", "-lc"]
+RUN micromamba create -y -n py310 -c conda-forge python=3.10 pip \
+ && micromamba run -n py310 python -m pip install --upgrade pip \
+ && micromamba run -n py310 pip install --no-cache-dir \
+      numpy==1.26.4 \
+      pillow \
+      tqdm \
+      libigl==2.5.1 \
+      open3d==0.18.0 \
+      wandb
+
+# Make this Python visible to subsequent steps
+ENV PATH="/opt/micromamba/envs/py310/bin:${PATH}"
+
 
 COPY . /src
 RUN rm /src/CMakeCache.txt || true
@@ -32,7 +58,7 @@ RUN mkdir /src/build
 WORKDIR /src/build
 
 RUN cmake -DVC_WITH_CUDA_SPARSE=off /src
-RUN make -j$(nproc --all)
+RUN make -j"$(nproc --all)"
 
 RUN cpack -G DEB -V
 
@@ -45,3 +71,5 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     && rm -rf /var/lib/apt/lists/*
 
 FROM base as default
+
+ENV WANDB_ENTITY="vesuvius-challenge"


### PR DESCRIPTION
Adds a button to SLIM Flatten & Render a segment

SLIM flattening happens for just 60 iterations now (hardcoded), but to be changed in the future

SLIM runs through a custom micromamba python environment (we should check this does not break usage of other python3 scripts)
As usual, SLIM for big meshes could be slow.

Wandb logging of stretch metrics is also performed.
To have wandb working, before running VC3D inside the docker one should `wandb login`.
It will save the flattening run in the flattening project in our wandb organization.

Still experimental, but seems to be working (at least locally, and on small segments)

P.S. I did some massive changes to both `tifxyz2obj` and `obj2tifxyz`, which now require as a default the UV map NOT to be normalized. Could this give some problems with Khartes segments integration?

