### PR TITLE
disable omp

### DIFF
--- a/apps/VC3D/CVolumeViewer.cpp
+++ b/apps/VC3D/CVolumeViewer.cpp
@@ -962,27 +962,27 @@ void CVolumeViewer::renderIntersections()
         for (auto key : _intersect_tgts)
             intersect_tgts_v.push_back(key);
 
-#pragma omp parallel for
+//#pragma omp parallel for
         for(int n=0;n<intersect_tgts_v.size();n++) {
             std::string key = intersect_tgts_v[n];
             bool haskey;
-#pragma omp critical
+//#pragma omp critical
             haskey = _intersect_items.count(key);
             if (!haskey && dynamic_cast<QuadSurface*>(_surf_col->surface(key))) {
                 QuadSurface *segmentation = dynamic_cast<QuadSurface*>(_surf_col->surface(key));
 
                 if (intersect(view_bbox, segmentation->bbox()))
-#pragma omp critical
+//#pragma omp critical
                     intersect_cands.push_back(key);
                 else
-#pragma omp critical
+//#pragma omp critical
                     _intersect_items[key] = {};
             }
         }
 
         std::vector<std::vector<std::vector<cv::Vec3f>>> intersections(intersect_cands.size());
 
-#pragma omp parallel for
+//#pragma omp parallel for
         for(int n=0;n<intersect_cands.size();n++) {
             std::string key = intersect_cands[n];
             QuadSurface *segmentation = dynamic_cast<QuadSurface*>(_surf_col->surface(key));
@@ -1085,11 +1085,11 @@ void CVolumeViewer::renderIntersections()
                 for (auto wp : seg)
                     src_locations.push_back(wp);
             
-#pragma omp parallel
+//#pragma omp parallel
             {
                 // SurfacePointer *ptr = crop->pointer();
                 SurfacePointer *ptr = _surf->pointer();
-#pragma omp for
+//#pragma omp for
                 for (auto wp : src_locations) {
                     // float res = crop->pointTo(ptr, wp, 2.0, 100);
                     // cv::Vec3f p = crop->loc(ptr)*_ds_scale + cv::Vec3f(_vis_center[0],_vis_center[1],0);
@@ -1099,7 +1099,7 @@ void CVolumeViewer::renderIntersections()
                     if (res >= 2.0)
                         p = {-1,-1,-1};
                         // std::cout << "WARNING pointTo() high residual in renderIntersections()" << std::endl;
-#pragma omp critical
+//#pragma omp critical
                     location_cache[wp] = p;
                 }
             }

--- a/apps/VC3D/CWindow.cpp
+++ b/apps/VC3D/CWindow.cpp
@@ -1128,7 +1128,7 @@ void CWindow::LoadSurfaces(bool reload)
     if (!to_load.empty()) {
         std::cout << "Loading " << to_load.size() << " new surfaces..." << std::endl;
         
-        #pragma omp parallel for
+        //#pragma omp parallel for
         for(int i = 0; i < to_load.size(); i++) {
             auto seg = fVpkg->segmentation(to_load[i].first);
             try {

--- a/apps/src/ObjAlphaCompRefinement.cpp
+++ b/apps/src/ObjAlphaCompRefinement.cpp
@@ -154,7 +154,7 @@ int process_obj(const std::string &src, const std::string &tgt, DSReader &reader
         float border_off = params.value<float>("border_off", 1.0);
         int r = params.value<int>("r", 3);
 
-#pragma omp parallel for
+//#pragma omp parallel for
         for(int j=0;j<vs.size();j++) {
             float off = alphacomp_offset(reader, vs[j], vns[j], start, stop, step, low, high, r);
             vs[j] += vns[j]*(off + border_off);

--- a/apps/src/TestChunkedCompute.cpp
+++ b/apps/src/TestChunkedCompute.cpp
@@ -35,7 +35,7 @@ template <typename T, typename E>
 void _dist_iteration(T &from, T &to, int s)
 {
     E magic = -1;
-#pragma omp parallel for
+//#pragma omp parallel for
     for(int k=0;k<s;k++)
         for(int j=0;j<s;j++)
             for(int i=0;i<s;i++) {
@@ -73,7 +73,7 @@ T distance_transform(const T &chunk, int steps, int size)
         _dist_iteration<T,E>(c2,c1,size);
     }
 
-    #pragma omp parallel for
+    //#pragma omp parallel for
     for(int z=0;z<size;z++)
         for(int y=0;y<size;y++)
             for(int x=0;x<size;x++)
@@ -95,7 +95,7 @@ struct thresholdedDistance
         int s = CHUNK_SIZE+2*BORDER;
         E magic = -1;
 
-#pragma omp parallel for
+//#pragma omp parallel for
         for(int z=0;z<s;z++)
             for(int y=0;y<s;y++)
                 for(int x=0;x<s;x++)
@@ -150,10 +150,10 @@ int main(int argc, char *argv[])
     //         for(int i=0;i<w;i++)
     //             img(j,i) = acc(4000,j,i);
     // }
-#pragma omp parallel
+//#pragma omp parallel
     {
         Chunked3dAccessor acc(proc_tensor);
-#pragma omp for
+//#pragma omp for
         for(int j=2000;j<3000;j++) {
             for(int i=2500;i<4500;i++)
                 img(j,i) = acc.safe_at(2000,j,i);

--- a/apps/src/ZarrAlphaComp.cpp
+++ b/apps/src/ZarrAlphaComp.cpp
@@ -174,7 +174,7 @@ cv::Mat_<cv::Vec3f> surf_alpha_integ_dbg(z5::Dataset *ds, ChunkCache *chunk_cach
 //     
 //     cv::Mat_<cv::Vec3f> dist = avg_surf-new_surf;
 //     
-//     #pragma omp parallel for
+//     //#pragma omp parallel for
 //     for(int j=0;j<points.rows;j++)
 //         for(int i=0;i<points.cols;i++) {
 //             rel_height(j,i) = cv::norm(dist(j,i));

--- a/apps/src/ZarrRenderBlur.cpp
+++ b/apps/src/ZarrRenderBlur.cpp
@@ -291,13 +291,13 @@ cv::Mat_<cv::Vec3f> derive_regular_region_stupid_gauss(cv::Mat_<cv::Vec3f> point
     
     cv::Mat trans = out.t();
     
-#pragma omp parallel for
+//#pragma omp parallel for
     for(int j=0;j<trans.rows;j++) 
         cv::GaussianBlur(trans({0,j,trans.cols,1}), blur({0,j,trans.cols,1}), {255,1}, 0);
 
     blur = blur.t();
     
-#pragma omp parallel for
+//#pragma omp parallel for
     for(int j=1;j<points.rows;j++)
         for(int i=1;i<points.cols-1;i++) {
             // min_loc(points, {i,j}, out(j,i), {out(j,i)[0],out(j,i)[1],out(j,i)[2]});
@@ -321,7 +321,7 @@ cv::Mat_<cv::Vec3f> derive_regular_region_stupid_gauss_indirect(cv::Mat_<cv::Vec
     
     int dist = 20;
     
-    #pragma omp parallel for
+    //#pragma omp parallel for
     for(int j=2*dist;j<points.rows-2*dist;j++)
         for(int i=2*dist;i<points.cols-2*dist;i++) {
             std::vector<cv::Vec3f> tgts = {blur(j-dist,i),blur(j+dist,i),blur(j,i+dist/5),blur(j,i-dist/5)};
@@ -348,7 +348,7 @@ cv::Mat_<cv::Vec3f> derive_regular_region(cv::Mat_<cv::Vec3f> points)
 
     cv::GaussianBlur(out, out, {1,255}, 0);
     
-#pragma omp parallel for
+//#pragma omp parallel for
     for(int j=1;j<points.rows;j++)
         for(int i=1;i<points.cols-1;i++) {
             // min_loc(points, {i,j}, out(j,i), {out(j,i)[0],out(j,i)[1],out(j,i)[2]});
@@ -382,9 +382,9 @@ cv::Mat_<cv::Vec3f> derive_regular_region(cv::Mat_<cv::Vec3f> points)
 //     float sqd = sqrt(2);
 //     
 // //     // float dist
-// // // #pragma omp parallel for
+// // // //#pragma omp parallel for
 //     for(int j=500;j<1000;j++)
-// #pragma omp parallel for
+// //#pragma omp parallel for
 //         for(int i=200;i<800;i++) {
 //             std::vector<cv::Vec3f> tgts = {out(j-1,i-1),out(j-1,i),out(j-1,i+1)};
 //             // std::vector<cv::Vec3f> tgts = {out(j-1,i-1),out(j-1,i),out(j-1,i+1),out(j-1,i-2),out(j-1,i+2)};
@@ -396,7 +396,7 @@ cv::Mat_<cv::Vec3f> derive_regular_region(cv::Mat_<cv::Vec3f> points)
 //         }
 //         
 //     for(int j=510;j<520;j++)
-//         // #pragma omp parallel for
+//         // //#pragma omp parallel for
 //         for(int i=200;i<800;i++) {
 //             out(j,i) = {-1,-1,-1};
 //         }*/
@@ -410,10 +410,10 @@ cv::Mat_<cv::Vec3f> derive_regular_region(cv::Mat_<cv::Vec3f> points)
 //         
 //     cv::Mat tmp(src.size(), src.type());
 // 
-// #pragma omp parallel for
+// //#pragma omp parallel for
 //     for(int j=0;j<src.rows;j++) 
 //         cv::GaussianBlur(src({0,j,src.cols,1}), tmp({0,j,src.cols,1}), {size,1}, 0);
-// #pragma omp parallel for
+// //#pragma omp parallel for
 //     for(int i=0;i<src.cols;i++) 
 //         cv::GaussianBlur(tmp({i,0,1, src.rows}), tgt({i,0,1, src.rows}), {1,size}, 0);
 // }

--- a/apps/src/vc_fill_quadmesh.cpp
+++ b/apps/src/vc_fill_quadmesh.cpp
@@ -743,7 +743,7 @@ cv::Mat_<cv::Vec3f> points_hr_grounding(const cv::Mat_<uint8_t> &state, std::vec
                     }
             }
 
-#pragma omp parallel for
+//#pragma omp parallel for
     for(int j=0;j<points_hr.rows;j++)
         for(int i=0;i<points_hr.cols;i++)
             if (counts_hr(j,i))
@@ -1228,7 +1228,7 @@ int main(int argc, char *argv[])
         
         std::cout << "proc col " << i << std::endl;
         ceres::Problem problem_col;
-#pragma omp parallel for
+//#pragma omp parallel for
         for(int j=std::max(bbox.y,lower_bound);j<std::min(bbox.br().y,upper_bound+1);j++) {
             cv::Vec2i p = {j,i};
 
@@ -1267,7 +1267,7 @@ int main(int argc, char *argv[])
         std::vector<int> add_idxs;
         
         //TODO re-use existing locs if there!
-#pragma omp parallel for
+//#pragma omp parallel for
         for(int j=bbox.y;j<bbox.br().y;j++) {
             for(int o=0;o<=opt_w;o++) {
                 //only add in area where we also inpaint
@@ -1283,7 +1283,7 @@ int main(int argc, char *argv[])
                     if (res >= 0 &&
                         cv::norm(at_int(surf_points[s], {loc[1],loc[0]}) - cv::Vec3f(points(po))) <= 100
                         && cv::norm(at_int(winds[s], {loc[1],loc[0]}) - tgt_wind[i-o]) <= wind_th)
-#pragma omp critical
+//#pragma omp critical
                         {
                             surf_locs[s](po) = loc;
                             add_idxs.push_back(s);

--- a/apps/src/vc_tiffxyz_upscale_grounding.cpp
+++ b/apps/src/vc_tiffxyz_upscale_grounding.cpp
@@ -239,7 +239,7 @@ cv::Mat_<cv::Vec3f> points_hr_grounding(cv::Mat_<float> wind_lr, const cv::Mat_<
                     }
                 }
 
-#pragma omp parallel for
+//#pragma omp parallel for
     for(int j=0;j<points_hr.rows;j++)
         for(int i=0;i<points_hr.cols;i++)
             if (counts_hr(j,i))

--- a/apps/src/vc_tifxyz_winding.cpp
+++ b/apps/src/vc_tifxyz_winding.cpp
@@ -304,10 +304,10 @@ int main(int argc, char *argv[])
     
     std::vector<IntersectVec> intersects(num_conn);
     
-#pragma omp parallel
+//#pragma omp parallel
     {
         unsigned int sr = omp_get_thread_num();
-#pragma omp for
+//#pragma omp for
         for(int i=0;i<num_conn;i++) {
             cv::Vec2i seed = {rand_r(&sr) % points.cols, rand_r(&sr) % points.rows};
             while (points(seed[1],seed[0])[0] == -1)
@@ -479,7 +479,7 @@ int main(int argc, char *argv[])
         cv::Rect bounds_inv(0,0,points.rows-1,points.cols-1);
         
         std::vector<cv::Vec2i> neighs = {{0,-1},{0,1},{1,0},{-1,0},{1,1},{-1,1},{1,-1},{-1,-1},{0,-4},{0,4},{4,0},{-4,0},{0,-16},{0,16},{16,0},{-16,0}};
-#pragma omp parallel for
+//#pragma omp parallel for
         for(int j=1;j<winding.rows-1;j++)
             for(int i=1;i<winding.cols-1;i++) {
                 cv::Vec2i p = {j,i};
@@ -537,7 +537,7 @@ int main(int argc, char *argv[])
             
             cv::Mat_<cv::Vec3b> vis(points.size(), {0,0,0});
             cv::Mat_<float> winding_err(points.size());
-#pragma omp parallel for
+//#pragma omp parallel for
             for(int j=0;j<winding.rows;j++)
                 for(int i=0;i<winding.cols;i++) {
                     if (wind_w(j,i)) {
@@ -546,7 +546,7 @@ int main(int argc, char *argv[])
                         vis(j,i) = wind_cols[w_num]*(1-f)+wind_cols[w_num+1]*f;
                     }
                 }
-#pragma omp parallel for
+//#pragma omp parallel for
             for(int j=0;j<winding.rows;j++)
                 for(int i=0;i<winding.cols-1;i++) {
                     if (wind_w(j,i) && wind_w(j,i+1)) {

--- a/core/include/vc/core/types/ChunkedTensor.hpp
+++ b/core/include/vc/core/types/ChunkedTensor.hpp
@@ -216,12 +216,12 @@ public:
                 _chunks[id] = chunk;
             }
             else {
-#pragma omp atomic
+//#pragma omp atomic
                 chunk_compute_collisions++;
                 munmap(chunk, len_bytes);
                 chunk = _chunks[id];
             }
-#pragma omp atomic
+//#pragma omp atomic
             chunk_compute_total++;
             _mutex.unlock();
 
@@ -269,13 +269,13 @@ public:
                 throw std::runtime_error("oops rename failed!");
         }
         else {
-#pragma omp atomic
+//#pragma omp atomic
             chunk_compute_collisions++;
             munmap(chunk, len_bytes);
             unlink(tmp_path.string().c_str());
             chunk = _chunks[id];
         }
-#pragma omp atomic
+//#pragma omp atomic
         chunk_compute_total++;
         _mutex.unlock();
 
@@ -312,11 +312,11 @@ public:
             _chunks[id] = chunk;
         }
         else {
-#pragma omp atomic
+//#pragma omp atomic
             chunk_compute_collisions++;
             chunk = _chunks[id];
         }
-#pragma omp atomic
+//#pragma omp atomic
         chunk_compute_total++;
         _mutex.unlock();
 
@@ -343,12 +343,12 @@ public:
     //     if (!_chunks.count(id))
     //         _chunks[id] = small;
     //     else {
-    //         #pragma omp atomic
+    //         //#pragma omp atomic
     //         chunk_compute_collisions++;
     //         delete small;
     //         small = _chunks[id];
     //     }
-    //     #pragma omp atomic
+    //     //#pragma omp atomic
     //     chunk_compute_total++;
     //     _mutex.unlock();
     //
@@ -485,7 +485,7 @@ public:
                 get_chunk_safe(p);
         }
 
-        #pragma omp atomic
+        //#pragma omp atomic
         total++;
 
         // size_t pos_xt = &_chunk->operator()(p[0]-_corner[0],p[1]-_corner[1],p[2]-_corner[2]) - &_chunk->operator()(0,0,0);
@@ -513,7 +513,7 @@ public:
 
     void get_chunk_safe(const cv::Vec3i &p)
     {
-        #pragma omp atomic
+        //#pragma omp atomic
         miss++;
         cv::Vec3i id = {p[0]/C::CHUNK_SIZE,p[1]/C::CHUNK_SIZE,p[2]/C::CHUNK_SIZE};
         _chunk = _ar.chunk_safe(id);

--- a/core/src/Segmentation.cpp
+++ b/core/src/Segmentation.cpp
@@ -120,7 +120,7 @@ Segmentation::AnnotationSet Segmentation::getAnnotationSet() const
         // Convert from raw (only double values) to long and double variant
         Segmentation::AnnotationSet as(raw.width());
         as.data_.resize(raw.width()*raw.height());
-#pragma omp parallel for
+//#pragma omp parallel for
         for (std::size_t h = 0; h < raw.height(); ++h) {
             for (std::size_t w = 0; w < raw.width(); ++w) {
                 as.data_[h*raw.width() + w] = Annotation((long)raw[h * raw.width() + w][0], (long)raw[h * raw.width() + w][1], raw[h * raw.width() + w][2], raw[h * raw.width() + w][3]);

--- a/core/src/Slicing.cpp
+++ b/core/src/Slicing.cpp
@@ -386,16 +386,16 @@ void readInterpolated3D(cv::Mat_<uint8_t> &out, z5::Dataset *ds,
         });
     std::mutex speculative_mutex;
 
-#pragma omp parallel
+//#pragma omp parallel
     {
         cv::Vec4i last_idx = {-1,-1,-1,-1};
         std::shared_ptr<xt::xarray<uint8_t>> chunk_ref;
         xt::xarray<uint8_t> *chunk = nullptr;
 
-#pragma omp for schedule(guided,1)
+//#pragma omp for schedule(guided,1)
         for(size_t y = 0;y<h;y++) {
             if (w*h > 10000000)
-#pragma omp critical
+//#pragma omp critical
             {
                 done++;
                 if (done % 100 == 0)
@@ -441,7 +441,7 @@ void readInterpolated3D(cv::Mat_<uint8_t> &out, z5::Dataset *ds,
 
                         if (should_speculate) {
                             // Launch speculative loading in a separate task
-                            #pragma omp task
+                            //#pragma omp task
                             {
                                 speculativeLoadNeighbors(ds, cache, group_idx,
                                                        ix, iy, iz);
@@ -517,7 +517,7 @@ void readInterpolated3D(cv::Mat_<uint8_t> &out, z5::Dataset *ds,
                 }
             }
         }
-        #pragma omp taskwait
+        //#pragma omp taskwait
     }
 }
 
@@ -675,13 +675,13 @@ cv::Mat_<cv::Vec3f> smooth_vc_segmentation(const cv::Mat_<cv::Vec3f> &points)
     
     cv::Mat trans = out.t();
     
-    #pragma omp parallel for
+    //#pragma omp parallel for
     for(int j=0;j<trans.rows;j++) 
         cv::GaussianBlur(trans({0,j,trans.cols,1}), blur({0,j,trans.cols,1}), {255,1}, 0);
     
     blur = blur.t();
     
-    #pragma omp parallel for
+    //#pragma omp parallel for
     for(int j=1;j<points.rows;j++)
         for(int i=1;i<points.cols-1;i++) {
             cv::Vec2f loc = {i,j};
@@ -711,7 +711,7 @@ void vc_segmentation_scales(cv::Mat_<cv::Vec3f> points, double &sx, double &sy)
         imax = points.size().width;
         step = 1;
     }
-#pragma omp parallel for
+//#pragma omp parallel for
     for(int j=jmin;j<jmax;j+=step) {
         double _sum_x = 0;
         double _sum_y = 0;
@@ -724,7 +724,7 @@ void vc_segmentation_scales(cv::Mat_<cv::Vec3f> points, double &sx, double &sy)
             _sum_y += sqrt(v.dot(v));
             _count++;
         }
-#pragma omp critical
+//#pragma omp critical
         {
             sum_x += _sum_x;
             sum_y += _sum_y;
@@ -741,7 +741,7 @@ cv::Mat_<cv::Vec3f> vc_segmentation_calc_normals(const cv::Mat_<cv::Vec3f> &poin
     cv::Mat_<cv::Vec3f> blur;
     cv::GaussianBlur(points, blur, {21,21}, 0);
     cv::Mat_<cv::Vec3f> normals(points.size());
-#pragma omp parallel for
+//#pragma omp parallel for
     for(int j=n_step;j<points.rows-n_step;j++)
         for(int i=n_step;i<points.cols-n_step;i++) {
             cv::Vec3f xv = normed(blur(j,i+n_step)-blur(j,i-n_step));
@@ -755,7 +755,7 @@ cv::Mat_<cv::Vec3f> vc_segmentation_calc_normals(const cv::Mat_<cv::Vec3f> &poin
         
         cv::GaussianBlur(normals, normals, {21,21}, 0);
         
-#pragma omp parallel for
+//#pragma omp parallel for
         for(int j=n_step;j<points.rows-n_step;j++)
             for(int i=n_step;i<points.cols-n_step;i++)
                 normals(j,i) = normed(normals(j,i));

--- a/core/src/Surface.cpp
+++ b/core/src/Surface.cpp
@@ -223,7 +223,7 @@ void PlaneSurface::gen(cv::Mat_<cv::Vec3f> *coords, cv::Mat_<cv::Vec3f> *normals
 
     cv::Vec3f use_origin = _origin + _normal*total_offset[2];
 
-#pragma omp parallel for
+//#pragma omp parallel for
     for(int j=0;j<h;j++)
         for(int i=0;i<w;i++) {
             (*coords)(j,i) = vx*(i*m+total_offset[0]) + vy*(j*m+total_offset[1]) + use_origin;

--- a/core/src/SurfaceHelpers.cpp
+++ b/core/src/SurfaceHelpers.cpp
@@ -250,13 +250,13 @@ static cv::Mat_<cv::Vec3f> derive_regular_region_stupid_gauss(cv::Mat_<cv::Vec3f
     
     cv::Mat trans = out.t();
     
-#pragma omp parallel for
+//#pragma omp parallel for
     for(int j=0;j<trans.rows;j++) 
         cv::GaussianBlur(trans({0,j,trans.cols,1}), blur({0,j,trans.cols,1}), {255,1}, 0);
 
     blur = blur.t();
     
-#pragma omp parallel for
+//#pragma omp parallel for
     for(int j=1;j<points.rows;j++)
         for(int i=1;i<points.cols-1;i++) {
             cv::Vec2f loc = {i,j};
@@ -599,7 +599,7 @@ cv::Mat_<cv::Vec3f> upsample_with_grounding_simple(const cv::Mat_<cv::Vec3f> &sm
     cv::Vec2f step = {sx*10, sy*10};
     cv::resize(locs, locs, large.size(), cv::INTER_CUBIC);
 
-#pragma omp parallel for
+//#pragma omp parallel for
     for(int j=0;j<large.rows;j++) {
         for(int i=0;i<large.cols;i++) {
             cv::Vec3f tgt = large(j,i);
@@ -923,7 +923,7 @@ public:
         if (_thread_idx[t_id] == -1)
             _thread_idx[t_id] = rand() % _thread_count;
         _thread_points[t_id] = {-1,-1};
-#pragma omp critical
+//#pragma omp critical
         _thread_points[t_id] = extract_point_min_dist(_points, _thread_points, _thread_idx[t_id], _dist);
         return _thread_points[t_id];
     }
@@ -949,7 +949,7 @@ template <typename T, typename E>
 void _dist_iteration(T &from, T &to, int s)
 {
     E magic = -1;
-#pragma omp parallel for
+//#pragma omp parallel for
     for(int k=0;k<s;k++)
         for(int j=0;j<s;j++)
             for(int i=0;i<s;i++) {
@@ -987,7 +987,7 @@ T distance_transform(const T &chunk, int steps, int size)
         _dist_iteration<T,E>(c2,c1,size);
     }
 
-#pragma omp parallel for
+//#pragma omp parallel for
     for(int z=0;z<size;z++)
         for(int y=0;y<size;y++)
             for(int x=0;x<size;x++)
@@ -1013,7 +1013,7 @@ struct thresholdedDistance
 
         int good_count = 0;
 
-#pragma omp parallel for
+//#pragma omp parallel for
         for(int z=0;z<s;z++)
             for(int y=0;y<s;y++)
                 for(int x=0;x<s;x++)
@@ -1222,7 +1222,7 @@ QuadSurface *space_tracing_quad_phys(z5::Dataset *ds, float scale, ChunkCache *c
 
         OmpThreadPointCol cands_threadcol(max_local_opt_r*2+1, cands);
 
-#pragma omp parallel
+//#pragma omp parallel
         {
             CachedChunked3dInterpolator<uint8_t,thresholdedDistance> interp(proc_tensor);
 //             int idx = rand() % cands.size();
@@ -1273,7 +1273,7 @@ QuadSurface *space_tracing_quad_phys(z5::Dataset *ds, float scale, ChunkCache *c
 
                 if (ref_count < 2 || ref_count+0.35*rec_ref_sum < curr_ref_min /*|| (generation > 3 && ref_count2 < 14)*/) {
                     state(p) &= ~STATE_PROCESSING;
-#pragma omp critical
+//#pragma omp critical
                     rest_ps.push_back(p);
                     continue;
                 }
@@ -1352,7 +1352,7 @@ QuadSurface *space_tracing_quad_phys(z5::Dataset *ds, float scale, ChunkCache *c
                     locs(p) = phys_only_loc;
                     state(p) = STATE_COORD_VALID;
                     if (global_opt) {
-#pragma omp critical
+//#pragma omp critical
                         loss_count += emptytrace_create_missing_centered_losses(big_problem, loss_status, p, state, locs, a1,a2,a3,a4, 
                                                                                 interp_global, proc_tensor, Ts, OPTIMIZE_ALL);
                     }
@@ -1367,31 +1367,31 @@ QuadSurface *space_tracing_quad_phys(z5::Dataset *ds, float scale, ChunkCache *c
                         }
                         if (err > phys_fail_th) {
                             std::cout << "local phys fail! " << err << std::endl;
-#pragma omp atomic
+//#pragma omp atomic
                             phys_fail_count++;
-#pragma omp atomic
+//#pragma omp atomic
                             phys_fail_count_gen++;
                         }
                     }
                 }
                 else {
                     if (global_opt) {
-#pragma omp critical
+//#pragma omp critical
                         loss_count += emptytrace_create_missing_centered_losses(big_problem, loss_status, p, state, locs, a1,a2,a3,a4, 
                                                                                 interp_global, proc_tensor, Ts);
                     }
-#pragma omp atomic
+//#pragma omp atomic
                     succ++;
-#pragma omp atomic
+//#pragma omp atomic
                     succ_gen++;
-#pragma omp critical
+//#pragma omp critical
                     {
                         if (!used_area.contains(cv::Point(p[1],p[0]))) {
                             used_area = used_area | cv::Rect(p[1],p[0],1,1);
                         }
                     }
                     
-#pragma omp critical
+//#pragma omp critical
                     {
                         fringe.push_back(p);
                         succ_gen_ps.push_back(p);
@@ -1440,7 +1440,7 @@ QuadSurface *space_tracing_quad_phys(z5::Dataset *ds, float scale, ChunkCache *c
             if (opt_local.size()) {
                 OmpThreadPointCol opt_local_threadcol(17, opt_local);
 
-#pragma omp parallel
+//#pragma omp parallel
                 while (true)
                 {
                     CachedChunked3dInterpolator<uint8_t,thresholdedDistance> interp(proc_tensor);
@@ -2157,7 +2157,7 @@ cv::Mat_<cv::Vec3d> surftrack_genpoints_hr(SurfTrackerData &data, cv::Mat_<uint8
 {
     cv::Mat_<cv::Vec3f> points_hr(state.rows*step, state.cols*step, {0,0,0});
     cv::Mat_<int> counts_hr(state.rows*step, state.cols*step, 0);
-#pragma omp parallel for //FIXME data access is just not threading friendly ...
+//#pragma omp parallel for //FIXME data access is just not threading friendly ...
     for(int j=used_area.y;j<used_area.br().y-1;j++)
         for(int i=used_area.x;i<used_area.br().x-1;i++) {
             if (state(j,i) & (STATE_LOC_VALID|STATE_COORD_VALID)
@@ -2211,7 +2211,7 @@ cv::Mat_<cv::Vec3d> surftrack_genpoints_hr(SurfTrackerData &data, cv::Mat_<uint8
             }
         }
     }
-#pragma omp parallel for
+//#pragma omp parallel for
     for(int j=0;j<points_hr.rows;j++)
         for(int i=0;i<points_hr.cols;i++)
             if (counts_hr(j,i))
@@ -2412,7 +2412,7 @@ void optimize_surface_mapping(SurfTrackerData &data, cv::Mat_<uint8_t> &state, c
     cv::Mat_<cv::Vec3d> points_out(points.size(), {-1,-1,-1});
     cv::Mat_<uint8_t> state_out(state.size(), 0);
     cv::Mat_<uint8_t> support_count(state.size(), 0);
-#pragma omp parallel for
+//#pragma omp parallel for
     for(int j=used_area.y;j<used_area.br().y;j++)
         for(int i=used_area.x;i<used_area.br().x;i++)
             if (static_bounds.contains(cv::Point(i,j))) {
@@ -2493,7 +2493,7 @@ void optimize_surface_mapping(SurfTrackerData &data, cv::Mat_<uint8_t> &state, c
         fringe_next.setTo(0);
         
         added = 0;
-#pragma omp parallel for collapse(2) schedule(dynamic)
+//#pragma omp parallel for collapse(2) schedule(dynamic)
         for(int j=used_area.y;j<used_area.br().y-1;j++)
             for(int i=used_area.x;i<used_area.br().x-1;i++)
                 if (!static_bounds.contains(cv::Point(i,j)) && state_out(j,i) & STATE_LOC_VALID && (fringe(j, i) || fringe_next(j, i))) {
@@ -2528,7 +2528,7 @@ void optimize_surface_mapping(SurfTrackerData &data, cv::Mat_<uint8_t> &state, c
                             continue;
                         
                         mutex.lock();
-#pragma omp atomic
+//#pragma omp atomic
                         added++;
                         data_out.surfs({j,i}).insert(test_surf);
                         data_out.loc(test_surf, {j,i}) = {loc_3d[1], loc_3d[0]};
@@ -2543,7 +2543,7 @@ void optimize_surface_mapping(SurfTrackerData &data, cv::Mat_<uint8_t> &state, c
     }
                      
     //reset unsupported points
-#pragma omp parallel for
+//#pragma omp parallel for
     for(int j=used_area.y;j<used_area.br().y-1;j++)
         for(int i=used_area.x;i<used_area.br().x-1;i++)
             if (!static_bounds.contains(cv::Point(i,j))) {
@@ -2768,7 +2768,7 @@ QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMe
 
             std::shared_mutex mutex;
             int best_inliers_gen = 0;
-#pragma omp parallel
+//#pragma omp parallel
         while (true)
         {
             cv::Vec2i p = threadcol.next();
@@ -3020,7 +3020,7 @@ QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMe
             else {
                 state(p) = 0;
                 points(p) = {-1,-1,-1};
-#pragma omp critical
+//#pragma omp critical
                 best_inliers_gen = std::max(best_inliers_gen, best_inliers);
             }
         }

--- a/core/src/SurfaceVoxelizer.cpp
+++ b/core/src/SurfaceVoxelizer.cpp
@@ -79,7 +79,7 @@ void SurfaceVoxelizer::voxelizeSurfaces(
     }
 
     // Process chunks in parallel
-    #pragma omp parallel for schedule(dynamic)
+    //#pragma omp parallel for schedule(dynamic)
     for (size_t i = 0; i < chunkCoords.size(); ++i) {
         size_t cx = chunkCoords[i][0];
         size_t cy = chunkCoords[i][1];
@@ -415,7 +415,7 @@ void SurfaceVoxelizer::downsampleLevel(
     }
 
     // Process pyramid chunks in parallel
-    #pragma omp parallel for schedule(dynamic)
+    //#pragma omp parallel for schedule(dynamic)
     for (size_t i = 0; i < pyramidChunkCoords.size(); ++i) {
         size_t dx = pyramidChunkCoords[i][0];
         size_t dy = pyramidChunkCoords[i][1];
@@ -441,7 +441,7 @@ void SurfaceVoxelizer::downsampleLevel(
         xt::xarray<uint8_t> srcChunk = xt::zeros<uint8_t>({src_nz, src_ny, src_nx});
 
         // Thread-safe read
-        #pragma omp critical(zarr_read_pyramid)
+        //#pragma omp critical(zarr_read_pyramid)
         {
             z5::types::ShapeType srcOffset = {src_z, src_y, src_x};
             z5::multiarray::readSubarray<uint8_t>(srcDs, srcChunk, srcOffset.begin());
@@ -465,7 +465,7 @@ void SurfaceVoxelizer::downsampleLevel(
         }
 
         // Thread-safe write
-        #pragma omp critical(zarr_write_pyramid)
+        //#pragma omp critical(zarr_write_pyramid)
         {
             z5::types::ShapeType dstOffset = {dz, dy, dx};
             z5::multiarray::writeSubarray<uint8_t>(dstDs, dstChunk, dstOffset.begin());


### PR DESCRIPTION
enabling OMP, even with `OMP_NESTED=false` and `OMP_NUM_THREADS=8` makes UI interactivity crap. Disabling all omp stuff makes the UI markedly more responsible.

We need to figure out what from these statements is _actually_ useful, what what isn't. At the moment, surface loading is a bit slower, and I can probably add back some omp stuff in the tracing code, but otherwise I think that most of the OMP stuff is doing more harm than good.