### PR TITLE
compile fix

### DIFF
--- a/core/src/Slicing.cpp
+++ b/core/src/Slicing.cpp
@@ -355,7 +355,6 @@ void readInterpolated3D(cv::Mat_<uint8_t> &out, z5::Dataset *ds,
 
         }
 
-#pragma omp paralle for schedule(dynamic)
     for(auto &it : chunks) {
         xt::xarray<uint8_t> *chunk = nullptr;
         std::shared_ptr<xt::xarray<uint8_t>> chunk_ref;


### PR DESCRIPTION
this line gives an invalid omp directive error as is, or a different error about weird template matching stuff when corrected. This part probably doesn't really need to be parallel anyway