### PR TITLE
Trace direction

### DIFF
--- a/apps/VC3D/CVolumeViewer.cpp
+++ b/apps/VC3D/CVolumeViewer.cpp
@@ -1829,6 +1829,10 @@ void CVolumeViewer::clearOverlayGroup(const std::string& key)
 // Shown on segmentation and projected into slice views.
 void CVolumeViewer::renderDirectionHints()
 {
+    if (!_showDirectionHints) {
+        clearOverlayGroup("direction_hints");
+        return;
+    }
     // Clear previous group
     clearOverlayGroup("direction_hints");
 

--- a/apps/VC3D/CVolumeViewer.hpp
+++ b/apps/VC3D/CVolumeViewer.hpp
@@ -77,6 +77,7 @@ public:
     
     // Direction hints for vc_grow_seg_from_segments flip_x visualization
     void renderDirectionHints();
+    void renderDirectionStepMarkers();
 
     // Generic overlay group management (ad-hoc helper for reuse)
     void setOverlayGroup(const std::string& key, const std::vector<QGraphicsItem*>& items);

--- a/apps/VC3D/CVolumeViewer.hpp
+++ b/apps/VC3D/CVolumeViewer.hpp
@@ -68,6 +68,10 @@ public:
     void setResetViewOnSurfaceChange(bool reset);
     bool isCompositeEnabled() const { return _composite_enabled; }
 
+    // Direction hints toggle
+    void setShowDirectionHints(bool on) { _showDirectionHints = on; updateAllOverlays(); }
+    bool isShowDirectionHints() const { return _showDirectionHints; }
+
     void fitSurfaceInView();
     void updateAllOverlays();
     
@@ -218,6 +222,7 @@ protected:
     float _brushSize = 3.0f;
     bool _brushIsSquare = false;
     bool _resetViewOnSurfaceChange = true;
+    bool _showDirectionHints = true;
 
     int _downscale_override = 0;  // 0=auto, 1=2x, 2=4x, 3=8x, 4=16x, 5=32x
     QTimer* _overlayUpdateTimer;

--- a/apps/VC3D/CVolumeViewer.hpp
+++ b/apps/VC3D/CVolumeViewer.hpp
@@ -6,6 +6,7 @@
 #include <opencv2/core/core.hpp>
 
 #include <set>
+#include <unordered_map>
 #include "PathData.hpp"
 #include "vc/core/util/VCCollection.hpp"
 #include "COutlinedTextItem.hpp"
@@ -69,6 +70,13 @@ public:
 
     void fitSurfaceInView();
     void updateAllOverlays();
+    
+    // Direction hints for vc_grow_seg_from_segments flip_x visualization
+    void renderDirectionHints();
+
+    // Generic overlay group management (ad-hoc helper for reuse)
+    void setOverlayGroup(const std::string& key, const std::vector<QGraphicsItem*>& items);
+    void clearOverlayGroup(const std::string& key);
 
     // Get current scale for coordinate transformation
     float getCurrentScale() const { return _scale; }
@@ -201,6 +209,9 @@ protected:
     
     QList<PathData> _paths;
     std::vector<QGraphicsItem*> _path_items;
+    
+    // Generic overlay groups; each key owns its items' lifetime
+    std::unordered_map<std::string, std::vector<QGraphicsItem*>> _overlay_groups;
     
     // Drawing mode state
     bool _drawingModeActive = false;

--- a/apps/VC3D/CWindow.hpp
+++ b/apps/VC3D/CWindow.hpp
@@ -256,6 +256,7 @@ private:
     QShortcut* fDefectiveShortcut;
     QShortcut* fDrawingModeShortcut;
     QShortcut* fCompositeViewShortcut;
+    QShortcut* fDirectionHintsShortcut;
 
 
 };  // class CWindow

--- a/apps/VC3D/SettingsDialog.cpp
+++ b/apps/VC3D/SettingsDialog.cpp
@@ -30,6 +30,18 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent)
     if (findChild<QCheckBox*>("chkShowDirectionHints")) {
         findChild<QCheckBox*>("chkShowDirectionHints")->setChecked(settings.value("viewer/show_direction_hints", true).toInt() != 0);
     }
+    // Direction step size default
+    if (auto* spin = findChild<QDoubleSpinBox*>("spinDirectionStep")) {
+        spin->setValue(settings.value("viewer/direction_step", 10.0).toDouble());
+    }
+    // Use segmentation step for hints
+    if (auto* chk = findChild<QCheckBox*>("chkUseSegStepForHints")) {
+        chk->setChecked(settings.value("viewer/use_seg_step_for_hints", true).toInt() != 0);
+    }
+    // Number of step points per direction
+    if (auto* spin = findChild<QSpinBox*>("spinDirectionStepPoints")) {
+        spin->setValue(settings.value("viewer/direction_step_points", 5).toInt());
+    }
 
     spinPreloadedSlices->setValue(settings.value("perf/preloaded_slices", 200).toInt());
     chkSkipImageFormatConvExp->setChecked(settings.value("perf/chkSkipImageFormatConvExp", false).toBool());
@@ -75,6 +87,15 @@ void SettingsDialog::accept()
     settings.setValue("viewer/reset_view_on_surface_change", chkResetViewOnSurfaceChange->isChecked() ? "1" : "0");
     if (findChild<QCheckBox*>("chkShowDirectionHints")) {
         settings.setValue("viewer/show_direction_hints", findChild<QCheckBox*>("chkShowDirectionHints")->isChecked() ? "1" : "0");
+    }
+    if (auto* spin = findChild<QDoubleSpinBox*>("spinDirectionStep")) {
+        settings.setValue("viewer/direction_step", spin->value());
+    }
+    if (auto* chk = findChild<QCheckBox*>("chkUseSegStepForHints")) {
+        settings.setValue("viewer/use_seg_step_for_hints", chk->isChecked() ? "1" : "0");
+    }
+    if (auto* spin = findChild<QSpinBox*>("spinDirectionStepPoints")) {
+        settings.setValue("viewer/direction_step_points", spin->value());
     }
 
     settings.setValue("perf/preloaded_slices", spinPreloadedSlices->value());

--- a/apps/VC3D/SettingsDialog.cpp
+++ b/apps/VC3D/SettingsDialog.cpp
@@ -26,6 +26,10 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent)
     chkPlaySoundAfterSegRun->setChecked(settings.value("viewer/play_sound_after_seg_run", true).toInt() != 0);
     edtUsername->setText(settings.value("viewer/username", "").toString());
     chkResetViewOnSurfaceChange->setChecked(settings.value("viewer/reset_view_on_surface_change", true).toInt() != 0);
+    // Show direction hints (flip_x arrows)
+    if (findChild<QCheckBox*>("chkShowDirectionHints")) {
+        findChild<QCheckBox*>("chkShowDirectionHints")->setChecked(settings.value("viewer/show_direction_hints", true).toInt() != 0);
+    }
 
     spinPreloadedSlices->setValue(settings.value("perf/preloaded_slices", 200).toInt());
     chkSkipImageFormatConvExp->setChecked(settings.value("perf/chkSkipImageFormatConvExp", false).toBool());
@@ -69,6 +73,9 @@ void SettingsDialog::accept()
     settings.setValue("viewer/play_sound_after_seg_run", chkPlaySoundAfterSegRun->isChecked() ? "1" : "0");
     settings.setValue("viewer/username", edtUsername->text());
     settings.setValue("viewer/reset_view_on_surface_change", chkResetViewOnSurfaceChange->isChecked() ? "1" : "0");
+    if (findChild<QCheckBox*>("chkShowDirectionHints")) {
+        settings.setValue("viewer/show_direction_hints", findChild<QCheckBox*>("chkShowDirectionHints")->isChecked() ? "1" : "0");
+    }
 
     settings.setValue("perf/preloaded_slices", spinPreloadedSlices->value());
     settings.setValue("perf/chkSkipImageFormatConvExp", chkSkipImageFormatConvExp->isChecked() ? "1" : "0");

--- a/apps/VC3D/VCSettings.ui
+++ b/apps/VC3D/VCSettings.ui
@@ -43,6 +43,62 @@
           </property>
          </widget>
         </item>
+        <item row="10" column="0">
+         <widget class="QLabel" name="labelDirectionStep">
+          <property name="text">
+           <string>Direction step size (default)</string>
+          </property>
+         </widget>
+        </item>
+        <item row="10" column="1">
+         <widget class="QDoubleSpinBox" name="spinDirectionStep">
+          <property name="decimals">
+           <number>2</number>
+          </property>
+          <property name="minimum">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>10000.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>1.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>10.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="11" column="0" colspan="2">
+         <widget class="QCheckBox" name="chkUseSegStepForHints">
+          <property name="text">
+           <string>Use segmentation step for hints</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="12" column="0">
+         <widget class="QLabel" name="labelDirectionStepPoints">
+          <property name="text">
+           <string>Step points per direction</string>
+          </property>
+         </widget>
+        </item>
+        <item row="12" column="1">
+         <widget class="QSpinBox" name="spinDirectionStepPoints">
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>5</number>
+          </property>
+         </widget>
+        </item>
          <item row="0" column="1">
           <widget class="QLineEdit" name="edtDefaultPathVolpkg"/>
          </item>

--- a/apps/VC3D/VCSettings.ui
+++ b/apps/VC3D/VCSettings.ui
@@ -31,8 +31,18 @@
            <property name="text">
             <string>Default *.volpkg path</string>
            </property>
-          </widget>
-         </item>
+         </widget>
+        </item>
+        <item row="9" column="0" colspan="2">
+         <widget class="QCheckBox" name="chkShowDirectionHints">
+          <property name="text">
+           <string>Show direction hints (flip_x arrows)</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
          <item row="0" column="1">
           <widget class="QLineEdit" name="edtDefaultPathVolpkg"/>
          </item>


### PR DESCRIPTION
add some helpful overlays for running traces

- render arrows on volume views for trace direction, using same logic as surfacehelpers.cpp 
      - green for true red for false
- render some points to show what the 'step' parameter will result in  with these arrows
- toggle with ctrl+t or settings