### PR TITLE
Avoid segfault if a point-collection is empty in calc_point_metrics

### DIFF
--- a/core/src/surface_metrics.cpp
+++ b/core/src/surface_metrics.cpp
@@ -129,6 +129,10 @@ nlohmann::json calc_point_metrics(const VCCollection& collection, QuadSurface* s
     for (const auto& pair : collection.getAllCollections()) {
         const auto& coll = pair.second;
 
+        if (coll.points.empty()) {
+            continue;
+        }
+
         std::vector<ColPoint> points;
         for (const auto& p_pair : coll.points) {
             points.push_back(p_pair.second);


### PR DESCRIPTION
...due to (size_t)0 - 1